### PR TITLE
service: add initial support for NodePort/LoadBalancer services

### DIFF
--- a/kind/single-node.yaml
+++ b/kind/single-node.yaml
@@ -11,3 +11,11 @@ nodes:
       - effect: NoSchedule
         key: mesh-cni.dev/startup
         value: "true"
+- role: worker
+  kubeadmConfigPatches:
+  - |
+    kind: KubeletConfiguration
+    registerWithTaints:
+      - effect: NoSchedule
+        key: mesh-cni.dev/startup
+        value: "true"

--- a/mesh-cni-ebpf-common/src/service.rs
+++ b/mesh-cni-ebpf-common/src/service.rs
@@ -90,6 +90,127 @@ impl ServiceKey {
     }
 }
 
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+pub struct NodePortKey {
+    pub port: u16,
+    pub protocol: u8,
+    pub _pad: u8,
+}
+
+#[cfg(feature = "user")]
+unsafe impl aya::Pod for NodePortKey {}
+
+impl NodePortKey {
+    pub const fn new(port: u16, protocol: u8) -> Self {
+        Self {
+            port,
+            protocol,
+            _pad: 0,
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+pub struct NodePortFrontendValue {
+    pub flags: u8,
+    pub _pad: [u8; 3],
+}
+
+#[cfg(feature = "user")]
+unsafe impl aya::Pod for NodePortFrontendValue {}
+
+pub const NODEPORT_FRONTEND_F_SNAT: u8 = 1 << 0;
+
+impl NodePortFrontendValue {
+    pub const fn with_snat(enabled: bool) -> Self {
+        Self {
+            flags: if enabled { NODEPORT_FRONTEND_F_SNAT } else { 0 },
+            _pad: [0, 0, 0],
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+pub struct NodePortNatV4Key {
+    pub src_ip: u32,
+    pub dst_ip: u32,
+    pub src_port: u16,
+    pub dst_port: u16,
+    pub protocol: u8,
+    pub _pad: [u8; 3],
+}
+
+#[cfg(feature = "user")]
+unsafe impl aya::Pod for NodePortNatV4Key {}
+
+impl NodePortNatV4Key {
+    pub const fn new(src_ip: u32, dst_ip: u32, src_port: u16, dst_port: u16, protocol: u8) -> Self {
+        Self {
+            src_ip,
+            dst_ip,
+            src_port,
+            dst_port,
+            protocol,
+            _pad: [0, 0, 0],
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+pub struct NodePortNatV4Value {
+    pub src_ip: u32,
+    pub dst_ip: u32,
+    pub src_port: u16,
+    pub dst_port: u16,
+    pub flags: u8,
+    pub _pad: [u8; 3],
+}
+
+#[cfg(feature = "user")]
+unsafe impl aya::Pod for NodePortNatV4Value {}
+
+pub const NODEPORT_NAT_REWRITE_SRC: u8 = 1 << 0;
+pub const NODEPORT_NAT_REWRITE_DST: u8 = 1 << 1;
+
+impl NodePortNatV4Value {
+    pub const fn new_src(src_ip: u32, src_port: u16) -> Self {
+        Self {
+            src_ip,
+            dst_ip: 0,
+            src_port,
+            dst_port: 0,
+            flags: NODEPORT_NAT_REWRITE_SRC,
+            _pad: [0, 0, 0],
+        }
+    }
+
+    pub const fn new_dst(dst_ip: u32, dst_port: u16) -> Self {
+        Self {
+            src_ip: 0,
+            dst_ip,
+            src_port: 0,
+            dst_port,
+            flags: NODEPORT_NAT_REWRITE_DST,
+            _pad: [0, 0, 0],
+        }
+    }
+
+    pub const fn new_src_dst(src_ip: u32, src_port: u16, dst_ip: u32, dst_port: u16) -> Self {
+        Self {
+            src_ip,
+            dst_ip,
+            src_port,
+            dst_port,
+            flags: NODEPORT_NAT_REWRITE_SRC | NODEPORT_NAT_REWRITE_DST,
+            _pad: [0, 0, 0],
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 pub enum EndpointValue {
     V4(EndpointValueV4),

--- a/mesh-cni-ebpf/src/lib.rs
+++ b/mesh-cni-ebpf/src/lib.rs
@@ -17,7 +17,8 @@ use mesh_cni_ebpf_common::{
         RulesetId,
     },
     service::{
-        EndpointKey, EndpointValueV4, EndpointValueV6, ServiceKeyV4, ServiceKeyV6, ServiceValue,
+        EndpointKey, EndpointValueV4, EndpointValueV6, NodePortFrontendValue, NodePortKey,
+        NodePortNatV4Key, NodePortNatV4Value, ServiceKeyV4, ServiceKeyV6, ServiceValue,
     },
 };
 
@@ -56,6 +57,24 @@ static ENDPOINTS_V4: HashMap<EndpointKey, EndpointValueV4> = HashMap::with_max_e
 
 #[map(name = "endpoints_v6")]
 static ENDPOINTS_V6: HashMap<EndpointKey, EndpointValueV6> = HashMap::with_max_entries(65535, 0);
+
+#[map(name = "nodeports_v4")]
+static NODEPORTS_V4: HashMap<NodePortKey, ServiceKeyV4> = HashMap::with_max_entries(65535, 0);
+
+#[map(name = "nodeports_v6")]
+static NODEPORTS_V6: HashMap<NodePortKey, ServiceKeyV6> = HashMap::with_max_entries(65535, 0);
+
+#[map(name = "nodeport_policies_v4")]
+static NODEPORT_POLICIES_V4: HashMap<NodePortKey, NodePortFrontendValue> =
+    HashMap::with_max_entries(65535, 0);
+
+#[map(name = "nodeport_policies_v6")]
+static NODEPORT_POLICIES_V6: HashMap<NodePortKey, NodePortFrontendValue> =
+    HashMap::with_max_entries(65535, 0);
+
+#[map(name = "nodeport_nat_v4")]
+static NODEPORT_NAT_V4: LruHashMap<NodePortNatV4Key, NodePortNatV4Value> =
+    LruHashMap::with_max_entries(262144, 0);
 
 #[inline]
 fn id_v4(ip: LpmKey<u32>) -> Option<IdentityId> {

--- a/mesh-cni-ebpf/src/main.rs
+++ b/mesh-cni-ebpf/src/main.rs
@@ -8,7 +8,9 @@ use aya_ebpf::{
 use mesh_cni_ebpf::{
     egress::try_mesh_cni_egress,
     ingress::try_mesh_cni_ingress,
-    service::{try_mesh_cni_cgroup_connect4, try_mesh_cni_nodeport_ingress},
+    service::{
+        try_mesh_cni_cgroup_connect4, try_mesh_cni_nodeport_egress, try_mesh_cni_nodeport_ingress,
+    },
 };
 
 #[cgroup_sock_addr(connect4)]
@@ -38,6 +40,14 @@ pub fn mesh_cni_egress(ctx: TcContext) -> i32 {
 #[classifier]
 pub fn mesh_cni_nodeport_ingress(ctx: TcContext) -> i32 {
     match try_mesh_cni_nodeport_ingress(ctx) {
+        Ok(ret) => ret,
+        Err(ret) => ret,
+    }
+}
+
+#[classifier]
+pub fn mesh_cni_nodeport_egress(ctx: TcContext) -> i32 {
+    match try_mesh_cni_nodeport_egress(ctx) {
         Ok(ret) => ret,
         Err(ret) => ret,
     }

--- a/mesh-cni-ebpf/src/service.rs
+++ b/mesh-cni-ebpf/src/service.rs
@@ -1,14 +1,23 @@
-use core::net::Ipv4Addr;
+use core::{mem::offset_of, net::Ipv4Addr};
 
 use aya_ebpf::{
-    bindings::{TC_ACT_PIPE, bpf_sock_addr},
+    bindings::{BPF_F_MARK_MANGLED_0, BPF_F_PSEUDO_HDR, TC_ACT_PIPE, bpf_sock_addr},
     helpers::generated::bpf_get_prandom_u32,
     programs::{SockAddrContext, TcContext},
 };
 use aya_log_ebpf::debug;
-use mesh_cni_ebpf_common::service::{EndpointKey, ServiceKeyV4};
+use mesh_cni_ebpf_common::service::{
+    EndpointKey, NODEPORT_FRONTEND_F_SNAT, NODEPORT_NAT_REWRITE_DST, NODEPORT_NAT_REWRITE_SRC,
+    NodePortKey, NodePortNatV4Key, NodePortNatV4Value, ServiceKeyV4,
+};
+use network_types::{
+    eth::{EthHdr, EtherType},
+    ip::{IpProto, Ipv4Hdr},
+    tcp::TcpHdr,
+    udp::UdpHdr,
+};
 
-use crate::{ENDPOINTS_V4, SERVICES_V4};
+use crate::{ENDPOINTS_V4, NODEPORT_NAT_V4, NODEPORT_POLICIES_V4, NODEPORTS_V4, SERVICES_V4};
 
 const AF_INET: u16 = 2;
 const _AF_INET6: u16 = 10;
@@ -103,6 +112,335 @@ fn get_position(count: u16) -> u16 {
 }
 
 #[inline]
-pub fn try_mesh_cni_nodeport_ingress(_ctx: TcContext) -> Result<i32, i32> {
+pub fn try_mesh_cni_nodeport_ingress(ctx: TcContext) -> Result<i32, i32> {
+    let ethhdr: EthHdr = ctx.load(0).map_err(|_| TC_ACT_PIPE)?;
+    let Ok(ether_type) = ethhdr.ether_type() else {
+        return Ok(TC_ACT_PIPE);
+    };
+
+    // TODO: handle IPv6
+    if !matches!(ether_type, EtherType::Ipv4) {
+        return Ok(TC_ACT_PIPE);
+    }
+
+    handle_nodeport_ingress_ipv4(ctx)
+}
+
+#[inline]
+pub fn try_mesh_cni_nodeport_egress(ctx: TcContext) -> Result<i32, i32> {
+    let ethhdr: EthHdr = ctx.load(0).map_err(|_| TC_ACT_PIPE)?;
+    let Ok(ether_type) = ethhdr.ether_type() else {
+        return Ok(TC_ACT_PIPE);
+    };
+
+    // TODO: handle IPv6
+    if !matches!(ether_type, EtherType::Ipv4) {
+        return Ok(TC_ACT_PIPE);
+    }
+
+    handle_nodeport_egress_ipv4(ctx)
+}
+
+#[inline]
+fn handle_nodeport_egress_ipv4(mut ctx: TcContext) -> Result<i32, i32> {
+    let packet = parse_nodeport_ipv4_packet(&ctx)?;
+
+    let nat_key = NodePortNatV4Key::new(
+        packet.src_ip,
+        packet.dst_ip,
+        packet.l4.src_port,
+        packet.l4.dst_port,
+        packet.protocol_u8,
+    );
+    if let Some(nat_value) = unsafe { NODEPORT_NAT_V4.get(nat_key).copied() } {
+        apply_nodeport_nat_v4(&mut ctx, &packet, nat_value)?;
+    }
     Ok(TC_ACT_PIPE)
+}
+
+#[inline]
+fn handle_nodeport_ingress_ipv4(mut ctx: TcContext) -> Result<i32, i32> {
+    let packet = parse_nodeport_ipv4_packet(&ctx)?;
+    let nat_key = NodePortNatV4Key::new(
+        packet.src_ip,
+        packet.dst_ip,
+        packet.l4.src_port,
+        packet.l4.dst_port,
+        packet.protocol_u8,
+    );
+    if let Some(nat_value) = unsafe { NODEPORT_NAT_V4.get(nat_key).copied() } {
+        apply_nodeport_nat_v4(&mut ctx, &packet, nat_value)?;
+        return Ok(TC_ACT_PIPE);
+    }
+
+    let nodeport_key = NodePortKey::new(packet.l4.dst_port, packet.protocol_u8);
+    let should_snat = unsafe {
+        NODEPORT_POLICIES_V4
+            .get(nodeport_key)
+            .map(|meta| (meta.flags & NODEPORT_FRONTEND_F_SNAT) != 0)
+            .unwrap_or(false)
+    };
+    let service_key = unsafe {
+        match NODEPORTS_V4.get(nodeport_key).copied() {
+            Some(key) => key,
+            None => return Ok(TC_ACT_PIPE),
+        }
+    };
+    let service_value = unsafe {
+        match SERVICES_V4.get(service_key).copied() {
+            Some(value) => value,
+            None => return Ok(TC_ACT_PIPE),
+        }
+    };
+    if service_value.count == 0 {
+        return Ok(TC_ACT_PIPE);
+    }
+
+    let forward_nat_value = unsafe {
+        let position = get_position(service_value.count);
+        let endpoint_key = EndpointKey::new(service_value.id, position);
+        let endpoint = match ENDPOINTS_V4.get(endpoint_key).copied() {
+            Some(value) => value,
+            None => return Ok(TC_ACT_PIPE),
+        };
+
+        // Forward mapping preserves backend affinity and applies DNAT (+ optional SNAT).
+        let forward_value = if should_snat {
+            NodePortNatV4Value::new_src_dst(
+                packet.dst_ip,
+                packet.l4.src_port,
+                endpoint.ip,
+                endpoint.port,
+            )
+        } else {
+            NodePortNatV4Value::new_dst(endpoint.ip, endpoint.port)
+        };
+        let _ = NODEPORT_NAT_V4.insert(nat_key, forward_value, 0);
+
+        // Reverse mapping rewrites backend replies back to nodeport frontend + original client tuple.
+        let reverse_key = NodePortNatV4Key::new(
+            endpoint.ip,
+            packet.dst_ip,
+            endpoint.port,
+            packet.l4.src_port,
+            packet.protocol_u8,
+        );
+        let reverse_value = if should_snat {
+            NodePortNatV4Value::new_src_dst(
+                packet.dst_ip,
+                packet.l4.dst_port,
+                packet.src_ip,
+                packet.l4.src_port,
+            )
+        } else {
+            NodePortNatV4Value::new_src(packet.dst_ip, packet.l4.dst_port)
+        };
+        let _ = NODEPORT_NAT_V4.insert(reverse_key, reverse_value, 0);
+
+        // Keep compatibility for direct backend->client return paths that hit tc egress.
+        let legacy_reverse_key = NodePortNatV4Key::new(
+            endpoint.ip,
+            packet.src_ip,
+            endpoint.port,
+            packet.l4.src_port,
+            packet.protocol_u8,
+        );
+        let legacy_reverse_value = NodePortNatV4Value::new_src(packet.dst_ip, packet.l4.dst_port);
+        let _ = NODEPORT_NAT_V4.insert(legacy_reverse_key, legacy_reverse_value, 0);
+
+        forward_value
+    };
+    apply_nodeport_nat_v4(&mut ctx, &packet, forward_nat_value)?;
+
+    Ok(TC_ACT_PIPE)
+}
+
+#[inline]
+fn apply_nodeport_nat_v4(
+    ctx: &mut TcContext,
+    packet: &NodePortPacketV4,
+    nat_value: NodePortNatV4Value,
+) -> Result<(), i32> {
+    let ipv4_check_offset = packet.ipv4_offset + offset_of!(Ipv4Hdr, check);
+
+    if (nat_value.flags & NODEPORT_NAT_REWRITE_SRC) != 0 {
+        let new_src_ip = nat_value.src_ip.to_be_bytes();
+        let new_src_ip_raw = u32::from_ne_bytes(new_src_ip);
+        let new_src_port = nat_value.src_port.to_be_bytes();
+        let new_src_port_raw = u16::from_ne_bytes(new_src_port);
+
+        if packet.old_src_ip_raw != new_src_ip_raw {
+            ctx.l3_csum_replace(
+                ipv4_check_offset,
+                packet.old_src_ip_raw as u64,
+                new_src_ip_raw as u64,
+                4,
+            )
+            .map_err(|_| TC_ACT_PIPE)?;
+
+            ctx.l4_csum_replace(
+                packet.l4.check_offset,
+                packet.old_src_ip_raw as u64,
+                new_src_ip_raw as u64,
+                l4_ip_flags(packet.l4.transport),
+            )
+            .map_err(|_| TC_ACT_PIPE)?;
+
+            let src_ip_offset = packet.ipv4_offset + offset_of!(Ipv4Hdr, src_addr);
+            ctx.store(src_ip_offset, &new_src_ip, 0)
+                .map_err(|_| TC_ACT_PIPE)?;
+        }
+
+        if packet.l4.src_port_raw != new_src_port_raw {
+            ctx.l4_csum_replace(
+                packet.l4.check_offset,
+                packet.l4.src_port_raw as u64,
+                new_src_port_raw as u64,
+                l4_port_flags(packet.l4.transport),
+            )
+            .map_err(|_| TC_ACT_PIPE)?;
+
+            ctx.store(packet.l4.src_port_offset, &new_src_port, 0)
+                .map_err(|_| TC_ACT_PIPE)?;
+        }
+    }
+
+    if (nat_value.flags & NODEPORT_NAT_REWRITE_DST) != 0 {
+        let new_dst_ip = nat_value.dst_ip.to_be_bytes();
+        let new_dst_ip_raw = u32::from_ne_bytes(new_dst_ip);
+        let new_dst_port = nat_value.dst_port.to_be_bytes();
+        let new_dst_port_raw = u16::from_ne_bytes(new_dst_port);
+
+        if packet.old_dst_ip_raw != new_dst_ip_raw {
+            ctx.l3_csum_replace(
+                ipv4_check_offset,
+                packet.old_dst_ip_raw as u64,
+                new_dst_ip_raw as u64,
+                4,
+            )
+            .map_err(|_| TC_ACT_PIPE)?;
+
+            ctx.l4_csum_replace(
+                packet.l4.check_offset,
+                packet.old_dst_ip_raw as u64,
+                new_dst_ip_raw as u64,
+                l4_ip_flags(packet.l4.transport),
+            )
+            .map_err(|_| TC_ACT_PIPE)?;
+
+            let dst_ip_offset = packet.ipv4_offset + offset_of!(Ipv4Hdr, dst_addr);
+            ctx.store(dst_ip_offset, &new_dst_ip, 0)
+                .map_err(|_| TC_ACT_PIPE)?;
+        }
+
+        if packet.l4.dst_port_raw != new_dst_port_raw {
+            ctx.l4_csum_replace(
+                packet.l4.check_offset,
+                packet.l4.dst_port_raw as u64,
+                new_dst_port_raw as u64,
+                l4_port_flags(packet.l4.transport),
+            )
+            .map_err(|_| TC_ACT_PIPE)?;
+
+            ctx.store(packet.l4.dst_port_offset, &new_dst_port, 0)
+                .map_err(|_| TC_ACT_PIPE)?;
+        }
+    }
+
+    Ok(())
+}
+
+struct NodePortPacketV4 {
+    ipv4_offset: usize,
+    protocol_u8: u8,
+    src_ip: u32,
+    dst_ip: u32,
+    old_src_ip_raw: u32,
+    old_dst_ip_raw: u32,
+    l4: L4State,
+}
+
+#[inline]
+fn parse_nodeport_ipv4_packet(ctx: &TcContext) -> Result<NodePortPacketV4, i32> {
+    let ipv4_offset = EthHdr::LEN;
+    let ipv4hdr: Ipv4Hdr = ctx.load(ipv4_offset).map_err(|_| TC_ACT_PIPE)?;
+    let ihl = ipv4hdr.ihl() as usize;
+    let is_fragmented = ipv4hdr.frag_offset() != 0 || (ipv4hdr.frag_flags() & 0x1) != 0;
+    if ihl < Ipv4Hdr::LEN || is_fragmented {
+        return Err(TC_ACT_PIPE);
+    }
+    let l4_offset = ipv4_offset + ihl;
+
+    Ok(NodePortPacketV4 {
+        ipv4_offset,
+        protocol_u8: ipv4hdr.proto as u8,
+        src_ip: u32::from_be_bytes(ipv4hdr.src_addr),
+        dst_ip: u32::from_be_bytes(ipv4hdr.dst_addr),
+        old_src_ip_raw: u32::from_ne_bytes(ipv4hdr.src_addr),
+        old_dst_ip_raw: u32::from_ne_bytes(ipv4hdr.dst_addr),
+        l4: parse_l4_state(ctx, l4_offset, ipv4hdr.proto)?,
+    })
+}
+
+#[derive(Clone, Copy)]
+enum Transport {
+    Tcp,
+    Udp,
+}
+
+struct L4State {
+    transport: Transport,
+    src_port: u16,
+    dst_port: u16,
+    src_port_raw: u16,
+    dst_port_raw: u16,
+    src_port_offset: usize,
+    dst_port_offset: usize,
+    check_offset: usize,
+}
+
+fn parse_l4_state(ctx: &TcContext, l4_offset: usize, protocol: IpProto) -> Result<L4State, i32> {
+    match protocol {
+        IpProto::Tcp => {
+            let tcphdr: TcpHdr = ctx.load(l4_offset).map_err(|_| TC_ACT_PIPE)?;
+            Ok(L4State {
+                transport: Transport::Tcp,
+                src_port: u16::from_be_bytes(tcphdr.source),
+                dst_port: u16::from_be_bytes(tcphdr.dest),
+                src_port_raw: u16::from_ne_bytes(tcphdr.source),
+                dst_port_raw: u16::from_ne_bytes(tcphdr.dest),
+                src_port_offset: l4_offset + offset_of!(TcpHdr, source),
+                dst_port_offset: l4_offset + offset_of!(TcpHdr, dest),
+                check_offset: l4_offset + offset_of!(TcpHdr, check),
+            })
+        }
+        IpProto::Udp => {
+            let udphdr: UdpHdr = ctx.load(l4_offset).map_err(|_| TC_ACT_PIPE)?;
+            Ok(L4State {
+                transport: Transport::Udp,
+                src_port: u16::from_be_bytes(udphdr.src),
+                dst_port: u16::from_be_bytes(udphdr.dst),
+                src_port_raw: u16::from_ne_bytes(udphdr.src),
+                dst_port_raw: u16::from_ne_bytes(udphdr.dst),
+                src_port_offset: l4_offset + offset_of!(UdpHdr, src),
+                dst_port_offset: l4_offset + offset_of!(UdpHdr, dst),
+                check_offset: l4_offset + offset_of!(UdpHdr, check),
+            })
+        }
+        _ => Err(TC_ACT_PIPE),
+    }
+}
+
+const fn l4_ip_flags(transport: Transport) -> u64 {
+    match transport {
+        Transport::Tcp => BPF_F_PSEUDO_HDR as u64 | 4,
+        Transport::Udp => BPF_F_PSEUDO_HDR as u64 | BPF_F_MARK_MANGLED_0 as u64 | 4,
+    }
+}
+
+const fn l4_port_flags(transport: Transport) -> u64 {
+    match transport {
+        Transport::Tcp => 2,
+        Transport::Udp => BPF_F_MARK_MANGLED_0 as u64 | 2,
+    }
 }

--- a/mesh-cni-service-bpf-controller/src/context.rs
+++ b/mesh-cni-service-bpf-controller/src/context.rs
@@ -8,6 +8,7 @@ pub struct Context<B>
 where
     B: ServiceBpfState,
 {
+    pub node_name: String,
     pub service_state: Store<Service>,
     pub endpoint_slice_state: Store<EndpointSlice>,
     pub mesh_endpoint_state: Store<MeshEndpoint>,

--- a/mesh-cni-service-bpf-controller/src/controller.rs
+++ b/mesh-cni-service-bpf-controller/src/controller.rs
@@ -5,21 +5,33 @@ use std::{
 };
 
 use ahash::{HashMap, HashSet};
-use k8s_openapi::api::core::v1::Service;
+use k8s_openapi::api::{
+    core::v1::Service,
+    discovery::v1::{EndpointConditions, EndpointSlice},
+};
 use kube::{Resource, ResourceExt, runtime::controller::Action};
 use mesh_cni_crds::v1alpha1::meshendpoint::{
     MeshEndpoint, coalesce_mesh_endpoints, generate_mesh_endpoint_spec, service_ips_from_service,
 };
-use mesh_cni_ebpf_common::service::{EndpointValue, ServiceKey};
+use mesh_cni_ebpf_common::{
+    KubeProtocol,
+    service::{EndpointValue, NodePortFrontendValue, NodePortKey, ServiceKey},
+};
 use mesh_cni_meshendpoint_gen_controller::ANNOTATION_MESH_SERVICE;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
-use crate::{Context, Error, Result, ServiceBpfState};
+use crate::{Context, Error, NodePortMapKey, Result, ServiceBpfState};
 
 const DEFAULT_REQUEUE_DURATION: Duration = Duration::from_secs(300);
 const ERROR_REQUEUE_DURATION: Duration = Duration::from_secs(300);
 const MISSING_MESH_ENDPOINT_REQUEUE_DURATION: Duration = Duration::from_secs(5);
 pub const SERVICE_OWNER_LABEL: &str = "kubernetes.io/service-name";
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ExternalTrafficPolicy {
+    Cluster,
+    Local,
+}
 
 pub async fn reconcile<B>(service: Arc<Service>, ctx: Arc<Context<B>>) -> Result<Action>
 where
@@ -45,7 +57,14 @@ pub async fn reconcile_local_service<B>(
 where
     B: ServiceBpfState,
 {
-    let desired = generate_desired_service_pairs(&service, &ctx);
+    let mut desired = generate_desired_service_pairs(&service, &ctx);
+    let external_traffic_policy = external_traffic_policy(&service);
+    let local_nodeport_services = filter_colliding_local_nodeport_services(
+        &service,
+        &desired,
+        generate_local_nodeport_service_pairs(&service, &ctx),
+    );
+    desired.extend(local_nodeport_services.clone());
     let current = ctx.service_bpf_state.state()?;
     let is_deletion = service.meta().deletion_timestamp.is_some();
     let (keys_to_remove, entries_to_upsert) =
@@ -58,6 +77,14 @@ where
     for (key, endpoints) in entries_to_upsert {
         ctx.service_bpf_state.update(key, endpoints)?;
     }
+    reconcile_nodeport(
+        &service,
+        &ctx,
+        &desired,
+        &local_nodeport_services,
+        external_traffic_policy,
+        is_deletion,
+    )?;
 
     Ok(Action::requeue(DEFAULT_REQUEUE_DURATION))
 }
@@ -69,7 +96,7 @@ pub async fn reconcile_multi_cluster_service<B>(
 where
     B: ServiceBpfState,
 {
-    let desired = generate_service_pairs_from_meps(&service, &ctx);
+    let mut desired = generate_service_pairs_from_meps(&service, &ctx);
     let current = ctx.service_bpf_state.state()?;
     let is_deletion = service.meta().deletion_timestamp.is_some();
     let mesh_endpoint_count = mesh_endpoint_count_for_service(&service, &ctx);
@@ -88,6 +115,13 @@ where
         );
         return Ok(Action::requeue(MISSING_MESH_ENDPOINT_REQUEUE_DURATION));
     }
+    let external_traffic_policy = external_traffic_policy(&service);
+    let local_nodeport_services = filter_colliding_local_nodeport_services(
+        &service,
+        &desired,
+        generate_local_nodeport_service_pairs(&service, &ctx),
+    );
+    desired.extend(local_nodeport_services.clone());
 
     let (keys_to_remove, entries_to_upsert) =
         diff_service_reconcile_actions(&service, &current, &desired, is_deletion);
@@ -99,6 +133,14 @@ where
     for (key, endpoints) in entries_to_upsert {
         ctx.service_bpf_state.update(key, endpoints)?;
     }
+    reconcile_nodeport(
+        &service,
+        &ctx,
+        &desired,
+        &local_nodeport_services,
+        external_traffic_policy,
+        is_deletion,
+    )?;
 
     Ok(Action::requeue(DEFAULT_REQUEUE_DURATION))
 }
@@ -129,6 +171,386 @@ fn generate_service_pairs_from_meps<B: ServiceBpfState>(
     let spec = coalesce_mesh_endpoints(&ctx.mesh_endpoint_state, service);
     let mesh_endpoint = MeshEndpoint::new("dummy", spec);
     mesh_endpoint.generate_bpf_service_endpoints(&service_ips)
+}
+
+fn reconcile_nodeport<B: ServiceBpfState>(
+    service: &Service,
+    ctx: &Context<B>,
+    desired_services: &HashMap<ServiceKey, Vec<EndpointValue>>,
+    local_nodeport_services: &HashMap<ServiceKey, Vec<EndpointValue>>,
+    external_traffic_policy: ExternalTrafficPolicy,
+    is_deletion: bool,
+) -> Result<()> {
+    let desired = generate_desired_nodeport(
+        service,
+        desired_services,
+        local_nodeport_services,
+        external_traffic_policy,
+    );
+    let desired_frontends = desired
+        .iter()
+        .map(|(frontend, value)| (*frontend, value.service_key))
+        .collect::<HashMap<_, _>>();
+    let current = ctx.service_bpf_state.nodeport_state()?;
+    let (keys_to_remove, entries_to_upsert) =
+        diff_nodeport_reconcile_actions(service, &current, &desired_frontends, is_deletion);
+
+    for key in keys_to_remove {
+        ctx.service_bpf_state.remove_nodeport_policy(&key)?;
+        ctx.service_bpf_state.remove_nodeport(&key)?;
+    }
+
+    for (key, service_key) in entries_to_upsert {
+        let Some(desired_value) = desired.get(&key) else {
+            continue;
+        };
+        ctx.service_bpf_state
+            .update_nodeport_policy(key, desired_value.policy)?;
+        ctx.service_bpf_state.update_nodeport(key, service_key)?;
+    }
+
+    Ok(())
+}
+
+#[derive(Clone, Copy)]
+struct DesiredNodePort {
+    service_key: ServiceKey,
+    policy: NodePortFrontendValue,
+}
+
+type NodePortKeyFamilyFn = fn(NodePortKey) -> NodePortMapKey;
+
+fn node_port_key_family(service_key: &ServiceKey) -> (u16, u8, NodePortKeyFamilyFn) {
+    match service_key {
+        ServiceKey::V4(v4) => (v4.port, v4.protocol, NodePortMapKey::V4),
+        ServiceKey::V6(v6) => (v6.port, v6.protocol, NodePortMapKey::V6),
+    }
+}
+
+fn generate_desired_nodeport(
+    service: &Service,
+    desired_services: &HashMap<ServiceKey, Vec<EndpointValue>>,
+    local_nodeport_services: &HashMap<ServiceKey, Vec<EndpointValue>>,
+    external_traffic_policy: ExternalTrafficPolicy,
+) -> HashMap<NodePortMapKey, DesiredNodePort> {
+    if external_traffic_policy == ExternalTrafficPolicy::Local {
+        return local_nodeport_services
+            .keys()
+            .map(|service_key| {
+                let (node_port, protocol, family) = node_port_key_family(service_key);
+                (
+                    family(NodePortKey::new(node_port, protocol)),
+                    DesiredNodePort {
+                        service_key: *service_key,
+                        policy: NodePortFrontendValue::with_snat(false),
+                    },
+                )
+            })
+            .collect();
+    }
+
+    let mut desired = HashMap::default();
+    let service_port_to_node_port = node_port_targets(service);
+    let local_by_frontend = local_nodeport_services
+        .keys()
+        .map(|service_key| {
+            let (node_port, protocol, family) = node_port_key_family(service_key);
+            (family(NodePortKey::new(node_port, protocol)), *service_key)
+        })
+        .collect::<HashMap<_, _>>();
+
+    for service_key in desired_services.keys() {
+        let (service_port, protocol, family) = node_port_key_family(service_key);
+
+        let Some(node_port) = service_port_to_node_port.get(&(service_port, protocol)) else {
+            continue;
+        };
+        let frontend_key = family(NodePortKey::new(*node_port, protocol));
+        let (target_service_key, should_snat) =
+            if let Some(local_key) = local_by_frontend.get(&frontend_key) {
+                (*local_key, false)
+            } else {
+                (*service_key, true)
+            };
+
+        desired.insert(
+            frontend_key,
+            DesiredNodePort {
+                service_key: target_service_key,
+                policy: NodePortFrontendValue::with_snat(should_snat),
+            },
+        );
+    }
+
+    desired
+}
+
+fn external_traffic_policy(service: &Service) -> ExternalTrafficPolicy {
+    let Some(spec) = service.spec.as_ref() else {
+        return ExternalTrafficPolicy::Cluster;
+    };
+    match spec.external_traffic_policy.as_deref() {
+        Some("Local") => ExternalTrafficPolicy::Local,
+        _ => ExternalTrafficPolicy::Cluster,
+    }
+}
+
+fn filter_colliding_local_nodeport_services(
+    service: &Service,
+    desired_services: &HashMap<ServiceKey, Vec<EndpointValue>>,
+    local_nodeport_services: HashMap<ServiceKey, Vec<EndpointValue>>,
+) -> HashMap<ServiceKey, Vec<EndpointValue>> {
+    local_nodeport_services
+        .into_iter()
+        .filter_map(|(service_key, endpoints)| {
+            if desired_services.contains_key(&service_key) {
+                warn!(
+                    service = %service.name_any(),
+                    namespace = service.namespace().unwrap_or_default(),
+                    ?service_key,
+                    "skipping Local nodeport-specific service key due to collision with base service key"
+                );
+                None
+            } else {
+                Some((service_key, endpoints))
+            }
+        })
+        .collect()
+}
+
+fn generate_local_nodeport_service_pairs<B: ServiceBpfState>(
+    service: &Service,
+    ctx: &Context<B>,
+) -> HashMap<ServiceKey, Vec<EndpointValue>> {
+    let mut result: HashMap<ServiceKey, Vec<EndpointValue>> = HashMap::default();
+    let service_ips = service_ips_from_service(service);
+    let targets = nodeport_targets_with_name(service);
+    if targets.is_empty() {
+        return result;
+    }
+    let slices = service_owned_endpoint_slices(service, ctx);
+    for slice in slices {
+        let slice = slice.as_ref();
+        let local_backend_ips = local_backend_ips_from_ep_slice(slice, &ctx.node_name);
+        if local_backend_ips.is_empty() {
+            continue;
+        }
+        for target in &targets {
+            let Some(backend_port) =
+                backend_port_from_ep_slice(slice, &target.name, target.protocol)
+            else {
+                continue;
+            };
+
+            for service_ip in &service_ips {
+                for backend_ip in &local_backend_ips {
+                    let endpoint = match (service_ip, backend_ip) {
+                        (IpAddr::V4(svc_v4), IpAddr::V4(ep_v4)) => {
+                            let key = ServiceKey::v4(
+                                svc_v4.to_bits(),
+                                target.node_port,
+                                target.protocol as u8,
+                            );
+                            let value =
+                                EndpointValue::V4(mesh_cni_ebpf_common::service::EndpointValueV4 {
+                                    ip: ep_v4.to_bits(),
+                                    port: backend_port,
+                                    _protocol: target.protocol as u8,
+                                });
+                            (key, value)
+                        }
+                        (IpAddr::V6(svc_v6), IpAddr::V6(ep_v6)) => {
+                            let key = ServiceKey::v6(
+                                svc_v6.to_bits(),
+                                target.node_port,
+                                target.protocol as u8,
+                            );
+                            let value =
+                                EndpointValue::V6(mesh_cni_ebpf_common::service::EndpointValueV6 {
+                                    ip: ep_v6.to_bits(),
+                                    port: backend_port,
+                                    _protocol: target.protocol as u8,
+                                });
+                            (key, value)
+                        }
+                        _ => continue,
+                    };
+                    result.entry(endpoint.0).or_default().push(endpoint.1);
+                }
+            }
+        }
+    }
+    result
+}
+
+struct NodePortTarget {
+    name: String,
+    node_port: u16,
+    protocol: KubeProtocol,
+}
+
+fn nodeport_targets_with_name(service: &Service) -> Vec<NodePortTarget> {
+    let mut targets = Vec::new();
+    let Some(spec) = service.spec.as_ref() else {
+        return targets;
+    };
+    let Some(ports) = spec.ports.as_ref() else {
+        return targets;
+    };
+    for port in ports {
+        let Some(node_port) = port.node_port else {
+            continue;
+        };
+        let Ok(node_port) = u16::try_from(node_port) else {
+            continue;
+        };
+        let protocol = match port.protocol.as_deref() {
+            Some(p) => KubeProtocol::try_from(p).unwrap_or_default(),
+            None => KubeProtocol::default(),
+        };
+        targets.push(NodePortTarget {
+            name: port.name.clone().unwrap_or_default(),
+            node_port,
+            protocol,
+        });
+    }
+    targets
+}
+
+fn service_owned_endpoint_slices<B: ServiceBpfState>(
+    service: &Service,
+    ctx: &Context<B>,
+) -> Vec<Arc<EndpointSlice>> {
+    let Some(namespace) = service.namespace() else {
+        return Vec::new();
+    };
+    let service_name = service.name_any();
+    ctx.endpoint_slice_state
+        .state()
+        .iter()
+        .filter(|slice| {
+            slice.namespace().as_deref() == Some(namespace.as_str())
+                && slice.labels().get(SERVICE_OWNER_LABEL) == Some(&service_name)
+        })
+        .cloned()
+        .collect()
+}
+
+fn endpoint_ready(ep_cond: &EndpointConditions) -> bool {
+    (ep_cond.ready == Some(true) || ep_cond.ready.is_none()) && (ep_cond.terminating != Some(true))
+}
+
+fn local_backend_ips_from_ep_slice(slice: &EndpointSlice, node_name: &str) -> Vec<IpAddr> {
+    let mut ips = Vec::new();
+    for endpoint in &slice.endpoints {
+        if endpoint.node_name.as_deref() != Some(node_name) {
+            continue;
+        }
+        let endpoint_is_ready = endpoint
+            .conditions
+            .as_ref()
+            .map(endpoint_ready)
+            .unwrap_or(true);
+        if !endpoint_is_ready {
+            continue;
+        }
+        for ip in &endpoint.addresses {
+            let Ok(ip) = ip.parse() else {
+                continue;
+            };
+            ips.push(ip);
+        }
+    }
+    ips
+}
+
+fn backend_port_from_ep_slice(
+    slice: &EndpointSlice,
+    name: &str,
+    protocol: KubeProtocol,
+) -> Option<u16> {
+    let Some(ports) = &slice.ports else {
+        return None;
+    };
+    for p in ports {
+        let name_matches = (name.is_empty() && p.name.is_none()) || p.name.as_deref() == Some(name);
+        if name_matches
+            && let Some(port) = p.port
+            && match p.protocol.as_deref() {
+                Some(proto) => KubeProtocol::try_from(proto).unwrap_or_default() == protocol,
+                None => KubeProtocol::default() == protocol,
+            }
+        {
+            return u16::try_from(port).ok();
+        }
+    }
+    None
+}
+
+fn node_port_targets(service: &Service) -> HashMap<(u16, u8), u16> {
+    let mut map = HashMap::default();
+    let Some(spec) = service.spec.as_ref() else {
+        return map;
+    };
+    let Some(ports) = spec.ports.as_ref() else {
+        return map;
+    };
+
+    for port in ports {
+        let Some(node_port) = port.node_port else {
+            continue;
+        };
+        let Ok(service_port) = u16::try_from(port.port) else {
+            continue;
+        };
+        let Ok(node_port) = u16::try_from(node_port) else {
+            continue;
+        };
+        let protocol = match port.protocol.as_deref() {
+            Some(p) => KubeProtocol::try_from(p).unwrap_or_default(),
+            None => KubeProtocol::default(),
+        } as u8;
+        map.insert((service_port, protocol), node_port);
+    }
+    map
+}
+
+fn nodeport_owned_keys(
+    service: &Service,
+    current_state: &HashMap<NodePortMapKey, ServiceKey>,
+) -> HashSet<NodePortMapKey> {
+    let ips = service_ip_sets(service);
+    current_state
+        .iter()
+        .filter_map(|(frontend_key, service_key)| {
+            if key_matches_service_ip(service_key, &ips) {
+                Some(*frontend_key)
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+fn diff_nodeport_reconcile_actions(
+    service: &Service,
+    current_state: &HashMap<NodePortMapKey, ServiceKey>,
+    desired_state: &HashMap<NodePortMapKey, ServiceKey>,
+    is_deletion: bool,
+) -> (HashSet<NodePortMapKey>, Vec<(NodePortMapKey, ServiceKey)>) {
+    let owned_keys = nodeport_owned_keys(service, current_state);
+    if is_deletion {
+        let mut keys_to_remove = owned_keys;
+        keys_to_remove.extend(desired_state.keys().copied());
+        return (keys_to_remove, Vec::new());
+    }
+
+    let keys_to_remove = owned_keys
+        .into_iter()
+        .filter(|key| !desired_state.contains_key(key))
+        .collect();
+    let entries_to_upsert = desired_state.iter().map(|(k, v)| (*k, *v)).collect();
+    (keys_to_remove, entries_to_upsert)
 }
 
 fn service_owned_keys(
@@ -238,10 +660,15 @@ mod tests {
     use k8s_openapi::api::core::v1::{Service, ServiceSpec};
     use mesh_cni_ebpf_common::{
         KubeProtocol,
-        service::{EndpointValue, EndpointValueV4, EndpointValueV6, ServiceKey},
+        service::{EndpointValue, EndpointValueV4, EndpointValueV6, NodePortKey, ServiceKey},
     };
 
-    use super::{diff_service_reconcile_actions, should_preserve_current_backends};
+    use crate::NodePortMapKey;
+
+    use super::{
+        diff_nodeport_reconcile_actions, diff_service_reconcile_actions,
+        should_preserve_current_backends,
+    };
 
     fn service_with_cluster_ips(ips: &[&str]) -> Service {
         Service {
@@ -279,6 +706,10 @@ mod tests {
             }),
         };
         vec![ep]
+    }
+
+    fn nodeport_v4(port: u16, protocol: KubeProtocol) -> NodePortMapKey {
+        NodePortMapKey::V4(NodePortKey::new(port, protocol as u8))
     }
 
     #[test]
@@ -411,5 +842,66 @@ mod tests {
     #[test]
     fn no_preserve_when_no_owned_backends_exist() {
         assert!(!should_preserve_current_backends(false, true, 0, 0));
+    }
+
+    #[test]
+    fn nodeport_diff_non_deletion_removes_stale_owned_frontend_keys() {
+        let service = service_with_cluster_ips(&["10.96.0.10"]);
+        let stale = nodeport_v4(30080, KubeProtocol::Tcp);
+        let desired_key = nodeport_v4(30443, KubeProtocol::Tcp);
+        let foreign = nodeport_v4(30999, KubeProtocol::Tcp);
+
+        let mut current = HashMap::default();
+        current.insert(stale, key(IpAddr::V4(Ipv4Addr::new(10, 96, 0, 10)), 80));
+        current.insert(
+            desired_key,
+            key(IpAddr::V4(Ipv4Addr::new(10, 96, 0, 10)), 443),
+        );
+        current.insert(foreign, key(IpAddr::V4(Ipv4Addr::new(10, 96, 0, 99)), 80));
+
+        let mut desired = HashMap::default();
+        desired.insert(
+            desired_key,
+            key(IpAddr::V4(Ipv4Addr::new(10, 96, 0, 10)), 443),
+        );
+
+        let (removes, upserts) =
+            diff_nodeport_reconcile_actions(&service, &current, &desired, false);
+
+        let expected_removes: HashSet<_> = [stale].into_iter().collect();
+        assert_eq!(removes, expected_removes);
+        let upserts: HashSet<_> = upserts.into_iter().collect();
+        let expected_upserts: HashSet<_> = [(
+            desired_key,
+            *desired.get(&desired_key).expect("desired key"),
+        )]
+        .into_iter()
+        .collect();
+        assert_eq!(upserts, expected_upserts);
+    }
+
+    #[test]
+    fn nodeport_diff_deletion_removes_owned_and_desired_keys() {
+        let service = service_with_cluster_ips(&["10.96.0.10"]);
+        let owned = nodeport_v4(30080, KubeProtocol::Tcp);
+        let desired_only = nodeport_v4(30443, KubeProtocol::Tcp);
+        let foreign = nodeport_v4(30999, KubeProtocol::Tcp);
+
+        let mut current = HashMap::default();
+        current.insert(owned, key(IpAddr::V4(Ipv4Addr::new(10, 96, 0, 10)), 80));
+        current.insert(foreign, key(IpAddr::V4(Ipv4Addr::new(10, 96, 0, 99)), 80));
+
+        let mut desired = HashMap::default();
+        desired.insert(
+            desired_only,
+            key(IpAddr::V4(Ipv4Addr::new(10, 96, 0, 10)), 443),
+        );
+
+        let (removes, upserts) =
+            diff_nodeport_reconcile_actions(&service, &current, &desired, true);
+
+        let expected_removes: HashSet<_> = [owned, desired_only].into_iter().collect();
+        assert_eq!(removes, expected_removes);
+        assert!(upserts.is_empty());
     }
 }

--- a/mesh-cni-service-bpf-controller/src/lib.rs
+++ b/mesh-cni-service-bpf-controller/src/lib.rs
@@ -4,15 +4,71 @@ mod error;
 mod runtime;
 mod utils;
 
+use std::sync::Arc;
+
 use ahash::HashMap;
 pub use context::Context;
 pub use controller::SERVICE_OWNER_LABEL;
 pub use error::{Error, Result};
-use mesh_cni_ebpf_common::service::{EndpointValue, ServiceKey};
+use mesh_cni_ebpf_common::service::{
+    EndpointValue, NodePortFrontendValue, NodePortKey, ServiceKey,
+};
 pub use runtime::start_bpf_service_controller;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+pub enum NodePortMapKey {
+    V4(NodePortKey),
+    V6(NodePortKey),
+}
 
 pub trait ServiceBpfState {
     fn update(&self, key: ServiceKey, value: Vec<EndpointValue>) -> Result<()>;
     fn remove(&self, key: &ServiceKey) -> Result<()>;
     fn state(&self) -> Result<HashMap<ServiceKey, Vec<EndpointValue>>>;
+    fn update_nodeport(&self, key: NodePortMapKey, value: ServiceKey) -> Result<()>;
+    fn remove_nodeport(&self, key: &NodePortMapKey) -> Result<()>;
+    fn update_nodeport_policy(
+        &self,
+        key: NodePortMapKey,
+        value: NodePortFrontendValue,
+    ) -> Result<()>;
+    fn remove_nodeport_policy(&self, key: &NodePortMapKey) -> Result<()>;
+    fn nodeport_state(&self) -> Result<HashMap<NodePortMapKey, ServiceKey>>;
+}
+
+impl<T> ServiceBpfState for Arc<T>
+where
+    T: ServiceBpfState + ?Sized,
+{
+    fn update(&self, key: ServiceKey, value: Vec<EndpointValue>) -> Result<()> {
+        (**self).update(key, value)
+    }
+
+    fn remove(&self, key: &ServiceKey) -> Result<()> {
+        (**self).remove(key)
+    }
+
+    fn state(&self) -> Result<HashMap<ServiceKey, Vec<EndpointValue>>> {
+        (**self).state()
+    }
+
+    fn update_nodeport(&self, key: NodePortMapKey, value: ServiceKey) -> Result<()> {
+        (**self).update_nodeport(key, value)
+    }
+
+    fn remove_nodeport(&self, key: &NodePortMapKey) -> Result<()> {
+        (**self).remove_nodeport(key)
+    }
+
+    fn update_nodeport_policy(&self, key: NodePortMapKey, value: NodePortFrontendValue) -> Result<()> {
+        (**self).update_nodeport_policy(key, value)
+    }
+
+    fn remove_nodeport_policy(&self, key: &NodePortMapKey) -> Result<()> {
+        (**self).remove_nodeport_policy(key)
+    }
+
+    fn nodeport_state(&self) -> Result<HashMap<NodePortMapKey, ServiceKey>> {
+        (**self).nodeport_state()
+    }
 }

--- a/mesh-cni-service-bpf-controller/src/runtime.rs
+++ b/mesh-cni-service-bpf-controller/src/runtime.rs
@@ -19,11 +19,12 @@ use crate::{
 
 pub async fn start_bpf_service_controller<B>(
     kube_client: Client,
+    node_name: String,
     service_bpf_state: B,
     cancel: CancellationToken,
 ) -> Result<()>
 where
-    B: ServiceBpfState + Clone + Send + Sync + 'static,
+    B: ServiceBpfState + Send + Sync + 'static,
 {
     let service_api: Api<Service> = Api::all(kube_client.clone());
     let (service_state, service_subscriber) =
@@ -41,6 +42,7 @@ where
     )
     .await?;
     let context = Context {
+        node_name,
         service_state: service_state.clone(),
         endpoint_slice_state,
         mesh_endpoint_state,

--- a/mesh-cni/src/agent.rs
+++ b/mesh-cni/src/agent.rs
@@ -10,7 +10,7 @@ use crate::{
         self,
         ip::IpNetworkState,
         policy::{PolicyBpfState, PolicyState},
-        service::{ServiceEndpoint, ServiceEndpointState},
+        service::{NodePortState, ServiceEndpoint, ServiceEndpointState},
     },
     config::AgentArgs,
     http, kubernetes,
@@ -62,19 +62,31 @@ pub async fn start(
     info!("loading service/endpoint bpf maps");
     let (service_map_v4, service_map_v6) = bpf::service::load_service_maps()?;
     let (endpoint_map_v4, endpoint_map_v6) = bpf::service::load_endpoint_maps()?;
+    let (nodeport_map_v4, nodeport_map_v6) = bpf::service::load_nodeport_maps()?;
+    let (nodeport_policy_map_v4, nodeport_policy_map_v6) =
+        bpf::service::load_nodeport_policy_maps()?;
 
     info!("starting kube service service");
     let service_endpoint_v4 = ServiceEndpoint::new(service_map_v4, endpoint_map_v4);
     let service_endpoint_v6 = ServiceEndpoint::new(service_map_v6, endpoint_map_v6);
-    let state = ServiceEndpointState::new(service_endpoint_v4, service_endpoint_v6);
+    let service_state = ServiceEndpointState::new(service_endpoint_v4, service_endpoint_v6);
+    let nodeport_state = NodePortState::new(
+        nodeport_map_v4,
+        nodeport_map_v6,
+        nodeport_policy_map_v4,
+        nodeport_policy_map_v6,
+    );
+    let controller_service_state =
+        bpf::service::ControllerServiceBpfState::new(service_state.clone(), nodeport_state);
     bpf::service::run(
         kube_client.clone(),
-        state.clone(),
+        args.node_name.clone(),
+        controller_service_state,
         args.proxy_settings.node_port_settings.clone(),
         cancel.clone(),
     )
     .await?;
-    let service_server = http::grpc::service::server(state);
+    let service_server = http::grpc::service::server(service_state);
 
     info!("starting conntrack cleanup background process");
     let cleanup_handle = tokio::spawn(bpf::conntrack::run_cleanup(cancel.clone()));

--- a/mesh-cni/src/bpf/loader.rs
+++ b/mesh-cni/src/bpf/loader.rs
@@ -15,8 +15,8 @@ use crate::{
     bpf::{
         BPF_LINK_CGROUP_CONNECT_V4_PATH, BPF_MESH_FS_DIR, BPF_MESH_LINKS_DIR, BPF_MESH_MAPS_DIR,
         BPF_MESH_PROG_DIR, BPF_PROGRAM_CGROUP_CONNECT_V4, BPF_PROGRAM_EGRESS_TC,
-        BPF_PROGRAM_INGRESS_TC, BPF_PROGRAM_NODEPORT_INGRESS_TC, BpfNamePath, POLICY_MAPS_LIST,
-        PROG_LIST, SERVICE_MAPS_LIST,
+        BPF_PROGRAM_INGRESS_TC, BPF_PROGRAM_NODEPORT_EGRESS_TC, BPF_PROGRAM_NODEPORT_INGRESS_TC,
+        BpfNamePath, POLICY_MAPS_LIST, PROG_LIST, SERVICE_MAPS_LIST,
     },
 };
 
@@ -46,6 +46,8 @@ pub fn init_bpf() -> Result<()> {
 
     info!("ensuring nodeport ingress program loaded and pinned");
     ensure_tc_program(&mut ebpf, BPF_PROGRAM_NODEPORT_INGRESS_TC)?;
+    info!("ensuring nodeport egress program loaded and pinned");
+    ensure_tc_program(&mut ebpf, BPF_PROGRAM_NODEPORT_EGRESS_TC)?;
 
     pin_maps(&mut ebpf, &SERVICE_MAPS_LIST)?;
     pin_maps(&mut ebpf, &POLICY_MAPS_LIST)?;
@@ -150,6 +152,9 @@ fn start_ebpf_logger() -> Result<()> {
 
     let nodeport_ingress = SchedClassifier::from_pin(BPF_PROGRAM_NODEPORT_INGRESS_TC.path())?;
     let info = nodeport_ingress.info()?;
+    start_ebpf_logger_from_prog_id(info.id())?;
+    let nodeport_egress = SchedClassifier::from_pin(BPF_PROGRAM_NODEPORT_EGRESS_TC.path())?;
+    let info = nodeport_egress.info()?;
     start_ebpf_logger_from_prog_id(info.id())?;
 
     Ok(())

--- a/mesh-cni/src/bpf/mod.rs
+++ b/mesh-cni/src/bpf/mod.rs
@@ -9,7 +9,7 @@ use std::{borrow::BorrowMut, hash::Hash};
 use anyhow::anyhow;
 use aya::{
     Pod,
-    maps::{HashMap, LpmTrie, MapData, lpm_trie::Key as LpmKey},
+    maps::{HashMap, LpmTrie, MapData, MapError, lpm_trie::Key as LpmKey},
 };
 use ipnetwork::IpNetwork;
 use mesh_cni_ebpf_common::IdentityId;
@@ -20,6 +20,8 @@ pub(crate) const BPF_PROGRAM_INGRESS_TC: BpfNamePath = BpfNamePath::Program("mes
 pub(crate) const BPF_PROGRAM_EGRESS_TC: BpfNamePath = BpfNamePath::Program("mesh_cni_egress");
 pub(crate) const BPF_PROGRAM_NODEPORT_INGRESS_TC: BpfNamePath =
     BpfNamePath::Program("mesh_cni_nodeport_ingress");
+pub(crate) const BPF_PROGRAM_NODEPORT_EGRESS_TC: BpfNamePath =
+    BpfNamePath::Program("mesh_cni_nodeport_egress");
 pub const BPF_PROGRAM_CGROUP_CONNECT_V4: BpfNamePath =
     BpfNamePath::Program("mesh_cni_cgroup_connect4");
 pub const BPF_LINK_CGROUP_CONNECT_V4_PATH: &str = "/sys/fs/bpf/mesh/links/mesh_cni_cgroup_connect4";
@@ -34,6 +36,11 @@ pub const BPF_MAP_SERVICES_V4: BpfNamePath = BpfNamePath::Map("services_v4");
 pub const BPF_MAP_SERVICES_V6: BpfNamePath = BpfNamePath::Map("services_v6");
 pub const BPF_MAP_ENDPOINTS_V4: BpfNamePath = BpfNamePath::Map("endpoints_v4");
 pub const BPF_MAP_ENDPOINTS_V6: BpfNamePath = BpfNamePath::Map("endpoints_v6");
+pub const BPF_MAP_NODEPORTS_V4: BpfNamePath = BpfNamePath::Map("nodeports_v4");
+pub const BPF_MAP_NODEPORTS_V6: BpfNamePath = BpfNamePath::Map("nodeports_v6");
+pub const BPF_MAP_NODEPORT_POLICIES_V4: BpfNamePath = BpfNamePath::Map("nodeport_policies_v4");
+pub const BPF_MAP_NODEPORT_POLICIES_V6: BpfNamePath = BpfNamePath::Map("nodeport_policies_v6");
+pub const BPF_MAP_NODEPORT_NAT_V4: BpfNamePath = BpfNamePath::Map("nodeport_nat_v4");
 pub const BPF_MAP_POLICY_INDEX: BpfNamePath = BpfNamePath::Map("policy_index");
 pub const BPF_MAP_POLICY_RULESET: BpfNamePath = BpfNamePath::Map("policy_ruleset");
 pub const BPF_MAP_POLICY_CIDR_V4: BpfNamePath = BpfNamePath::Map("policy_cidr_v4");
@@ -54,18 +61,24 @@ pub(crate) const POLICY_MAPS_LIST: [BpfNamePath; 7] = [
     BPF_MAP_POLICY_CIDR_V6,
 ];
 
-pub(crate) const SERVICE_MAPS_LIST: [BpfNamePath; 4] = [
+pub(crate) const SERVICE_MAPS_LIST: [BpfNamePath; 9] = [
     BPF_MAP_SERVICES_V4,
     BPF_MAP_SERVICES_V6,
     BPF_MAP_ENDPOINTS_V4,
     BPF_MAP_ENDPOINTS_V6,
+    BPF_MAP_NODEPORTS_V4,
+    BPF_MAP_NODEPORTS_V6,
+    BPF_MAP_NODEPORT_POLICIES_V4,
+    BPF_MAP_NODEPORT_POLICIES_V6,
+    BPF_MAP_NODEPORT_NAT_V4,
 ];
 
-pub(crate) const PROG_LIST: [BpfNamePath; 4] = [
+pub(crate) const PROG_LIST: [BpfNamePath; 5] = [
     BPF_PROGRAM_CGROUP_CONNECT_V4,
     BPF_PROGRAM_INGRESS_TC,
     BPF_PROGRAM_EGRESS_TC,
     BPF_PROGRAM_NODEPORT_INGRESS_TC,
+    BPF_PROGRAM_NODEPORT_EGRESS_TC,
 ];
 
 pub enum BpfNamePath {
@@ -109,6 +122,15 @@ pub trait SharedBpfMap: Send + Sync + 'static {
     fn get_state(&self) -> Result<ahash::HashMap<Self::KeyOutput, Self::Value>>;
 }
 
+fn is_not_found_delete_error(error: &MapError) -> bool {
+    match error {
+        MapError::SyscallError(syscall_error) => {
+            syscall_error.io_error.kind() == std::io::ErrorKind::NotFound
+        }
+        _ => false,
+    }
+}
+
 impl<T, K, V> BpfMap for HashMap<T, K, V>
 where
     T: BorrowMut<MapData>,
@@ -122,7 +144,11 @@ where
         Ok(self.insert(key, value, 0)?)
     }
     fn delete(&mut self, key: &K) -> Result<()> {
-        Ok(self.remove(key)?)
+        match self.remove(key) {
+            Ok(()) => Ok(()),
+            Err(error) if is_not_found_delete_error(&error) => Ok(()),
+            Err(error) => Err(error.into()),
+        }
     }
     fn get(&self, key: &K) -> Result<V> {
         Ok(<HashMap<T, K, V>>::get(self, key, 0)?)
@@ -180,7 +206,11 @@ where
         Ok(self.insert(&key, value, 0)?)
     }
     fn delete(&mut self, key: &Self::Key) -> Result<()> {
-        Ok(self.remove(key)?)
+        match self.remove(key) {
+            Ok(()) => Ok(()),
+            Err(error) if is_not_found_delete_error(&error) => Ok(()),
+            Err(error) => Err(error.into()),
+        }
     }
     fn get(&self, key: &Self::Key) -> Result<Self::Value> {
         Ok(<LpmTrie<T, u32, V>>::get(self, key, 0)?)
@@ -213,7 +243,11 @@ where
         Ok(self.insert(&key, value, 0)?)
     }
     fn delete(&mut self, key: &Self::Key) -> Result<()> {
-        Ok(self.remove(key)?)
+        match self.remove(key) {
+            Ok(()) => Ok(()),
+            Err(error) if is_not_found_delete_error(&error) => Ok(()),
+            Err(error) => Err(error.into()),
+        }
     }
     fn get(&self, key: &Self::Key) -> Result<Self::Value> {
         Ok(<LpmTrie<T, u128, V>>::get(self, key, 0)?)

--- a/mesh-cni/src/bpf/service/mod.rs
+++ b/mesh-cni/src/bpf/service/mod.rs
@@ -1,46 +1,85 @@
 mod nodeport_iface;
 mod state;
 
+use std::sync::Arc;
+
 use aya::maps::{HashMap, Map, MapData};
 use kube::Client;
 use mesh_cni_ebpf_common::service::{
-    EndpointKey, EndpointValueV4, EndpointValueV6, ServiceKeyV4, ServiceKeyV6, ServiceValue,
+    EndpointKey, EndpointValueV4, EndpointValueV6, NodePortFrontendValue, NodePortKey,
+    ServiceKeyV4, ServiceKeyV6, ServiceValue,
 };
-use mesh_cni_service_bpf_controller::start_bpf_service_controller;
-pub use state::{ServiceEndpoint, ServiceEndpointBpfMap, ServiceEndpointState};
+use mesh_cni_service_bpf_controller::{ServiceBpfState, start_bpf_service_controller};
+pub use state::{
+    ControllerServiceBpfState, NodePortState, ServiceEndpoint, ServiceEndpointBpfMap,
+    ServiceEndpointState,
+};
 use tokio_util::sync::CancellationToken;
-use tracing::info;
+use tracing::{info, warn};
 
 use crate::{
     Result,
-    bpf::{BPF_MAP_ENDPOINTS_V4, BPF_MAP_ENDPOINTS_V6, BPF_MAP_SERVICES_V4, BPF_MAP_SERVICES_V6},
+    bpf::{
+        BPF_MAP_ENDPOINTS_V4, BPF_MAP_ENDPOINTS_V6, BPF_MAP_NODEPORT_POLICIES_V4,
+        BPF_MAP_NODEPORT_POLICIES_V6, BPF_MAP_NODEPORTS_V4, BPF_MAP_NODEPORTS_V6,
+        BPF_MAP_SERVICES_V4, BPF_MAP_SERVICES_V6,
+    },
     config::NodePortSettings,
 };
 type ServiceMapV4 = HashMap<MapData, ServiceKeyV4, ServiceValue>;
 type ServiceMapV6 = HashMap<MapData, ServiceKeyV6, ServiceValue>;
 type EndpointMapV4 = HashMap<MapData, EndpointKey, EndpointValueV4>;
 type EndpointMapV6 = HashMap<MapData, EndpointKey, EndpointValueV6>;
+type NodePortFrontendMapV4 = HashMap<MapData, NodePortKey, ServiceKeyV4>;
+type NodePortFrontendMapV6 = HashMap<MapData, NodePortKey, ServiceKeyV6>;
+type NodePortPolicyMapV4 = HashMap<MapData, NodePortKey, NodePortFrontendValue>;
+type NodePortPolicyMapV6 = HashMap<MapData, NodePortKey, NodePortFrontendValue>;
 
-pub async fn run<SE4, SE6>(
+pub async fn run<B>(
     kube_client: Client,
-    service_bpf_state: ServiceEndpointState<SE4, SE6>,
+    node_name: String,
+    service_bpf_state: B,
     node_port_settings: NodePortSettings,
     cancel: CancellationToken,
 ) -> Result<()>
 where
-    SE4: ServiceEndpointBpfMap<SKey = ServiceKeyV4, EValue = EndpointValueV4>
-        + Send
-        + Sync
-        + 'static,
-    SE6: ServiceEndpointBpfMap<SKey = ServiceKeyV6, EValue = EndpointValueV6>
-        + Send
-        + Sync
-        + 'static,
+    B: ServiceBpfState + Send + Sync + 'static,
 {
-    let service_controller =
-        start_bpf_service_controller(kube_client, service_bpf_state, cancel.child_token());
+    let service_bpf_state = Arc::new(service_bpf_state);
+    let service_cancel = cancel.child_token();
+    tokio::spawn(async move {
+        let mut backoff = std::time::Duration::from_secs(2);
+        loop {
+            if service_cancel.is_cancelled() {
+                break;
+            }
+            let run_result = start_bpf_service_controller(
+                kube_client.clone(),
+                node_name.clone(),
+                service_bpf_state.clone(),
+                service_cancel.child_token(),
+            )
+            .await;
 
-    tokio::spawn(service_controller);
+            if service_cancel.is_cancelled() {
+                break;
+            }
+            match run_result {
+                Ok(()) => {
+                    warn!("service controller exited; restarting");
+                }
+                Err(err) => {
+                    warn!(%err, "service controller startup/runtime failed; retrying");
+                }
+            }
+            tokio::select! {
+                _ = service_cancel.cancelled() => break,
+                _ = tokio::time::sleep(backoff) => {}
+            }
+            backoff = std::cmp::min(backoff * 2, std::time::Duration::from_secs(30));
+        }
+    });
+
     nodeport_iface::start_nodeport_iface_reconciler(node_port_settings, cancel.child_token())?;
 
     Ok(())
@@ -68,6 +107,34 @@ pub fn load_endpoint_maps() -> Result<(EndpointMapV4, EndpointMapV6)> {
 
     info!("loading v6 endpoint map");
     let ipv6_map = MapData::from_pin(BPF_MAP_ENDPOINTS_V6.path())?;
+    let ipv6_map = Map::HashMap(ipv6_map);
+    let ipv6_map = ipv6_map.try_into()?;
+
+    Ok((ipv4_map, ipv6_map))
+}
+
+pub fn load_nodeport_maps() -> Result<(NodePortFrontendMapV4, NodePortFrontendMapV6)> {
+    info!("loading v4 nodeport frontend map");
+    let ipv4_map = MapData::from_pin(BPF_MAP_NODEPORTS_V4.path())?;
+    let ipv4_map = Map::HashMap(ipv4_map);
+    let ipv4_map = ipv4_map.try_into()?;
+
+    info!("loading v6 nodeport frontend map");
+    let ipv6_map = MapData::from_pin(BPF_MAP_NODEPORTS_V6.path())?;
+    let ipv6_map = Map::HashMap(ipv6_map);
+    let ipv6_map = ipv6_map.try_into()?;
+
+    Ok((ipv4_map, ipv6_map))
+}
+
+pub fn load_nodeport_policy_maps() -> Result<(NodePortPolicyMapV4, NodePortPolicyMapV6)> {
+    info!("loading v4 nodeport policy map");
+    let ipv4_map = MapData::from_pin(BPF_MAP_NODEPORT_POLICIES_V4.path())?;
+    let ipv4_map = Map::HashMap(ipv4_map);
+    let ipv4_map = ipv4_map.try_into()?;
+
+    info!("loading v6 nodeport policy map");
+    let ipv6_map = MapData::from_pin(BPF_MAP_NODEPORT_POLICIES_V6.path())?;
     let ipv6_map = Map::HashMap(ipv6_map);
     let ipv6_map = ipv6_map.try_into()?;
 

--- a/mesh-cni/src/bpf/service/nodeport_iface.rs
+++ b/mesh-cni/src/bpf/service/nodeport_iface.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{BTreeMap, BTreeSet},
+    collections::BTreeSet,
     fs,
     path::{Path, PathBuf},
     time::Duration,
@@ -17,13 +17,14 @@ use tracing::{info, warn};
 
 use crate::{
     Result,
-    bpf::{BPF_MESH_LINKS_DIR, BPF_PROGRAM_NODEPORT_INGRESS_TC},
+    bpf::{BPF_MESH_LINKS_DIR, BPF_PROGRAM_NODEPORT_EGRESS_TC, BPF_PROGRAM_NODEPORT_INGRESS_TC},
     config::NodePortSettings,
 };
 
 const HOST_NET_IFACE_DIR: &str = "/sys/class/net";
 const NODEPORT_LINK_PREFIX: &str = "mesh_cni_nodeport_";
-const NODEPORT_LINK_SUFFIX: &str = "_ingress";
+const NODEPORT_LINK_SUFFIX_INGRESS: &str = "_ingress";
+const NODEPORT_LINK_SUFFIX_EGRESS: &str = "_egress";
 const RECONCILE_INTERVAL: Duration = Duration::from_secs(30);
 
 pub fn start_nodeport_iface_reconciler(
@@ -41,11 +42,12 @@ pub fn start_nodeport_iface_reconciler(
         regex = %node_port_settings.node_port_iface_regex,
         "starting nodeport interface reconciler"
     );
+    reconcile(&iface_regex)?;
 
     let mut interval = tokio::time::interval(RECONCILE_INTERVAL);
 
+    // TODO: investigate if this can event driven using rtnetlink
     tokio::spawn(async move {
-        // TODO: investigate if this can event driven using rtnetlink
         loop {
             if let Err(err) = reconcile(&iface_regex) {
                 warn!(%err, "nodeport interface reconciliation failed");
@@ -68,7 +70,9 @@ fn reconcile(iface_regex: &Regex) -> Result<()> {
     let current_links = get_pinned_iface_links()?;
 
     for iface in &desired_ifaces {
-        ensure_nodeport_attached(iface)?;
+        ensure_ipv4_accept_local_enabled(iface)?;
+        ensure_nodeport_attached(iface, TcAttachType::Ingress)?;
+        ensure_nodeport_attached(iface, TcAttachType::Egress)?;
     }
 
     for (iface, link_path) in current_links {
@@ -86,6 +90,17 @@ fn reconcile(iface_regex: &Regex) -> Result<()> {
     Ok(())
 }
 
+fn ensure_ipv4_accept_local_enabled(iface: &str) -> Result<()> {
+    let path = format!("/proc/sys/net/ipv4/conf/{iface}/accept_local");
+    let current = fs::read_to_string(&path)?;
+    if current.trim() == "1" {
+        return Ok(());
+    }
+    fs::write(&path, b"1")?;
+    info!(iface = %iface, path = %path, "enabled ipv4 accept_local for nodeport forwarding");
+    Ok(())
+}
+
 fn get_matching_ifaces(iface_regex: &Regex) -> Result<BTreeSet<String>> {
     let mut names = BTreeSet::new();
     for entry in fs::read_dir(HOST_NET_IFACE_DIR)? {
@@ -100,8 +115,8 @@ fn get_matching_ifaces(iface_regex: &Regex) -> Result<BTreeSet<String>> {
     Ok(names)
 }
 
-fn get_pinned_iface_links() -> Result<BTreeMap<String, PathBuf>> {
-    let mut links = BTreeMap::new();
+fn get_pinned_iface_links() -> Result<Vec<(String, PathBuf)>> {
+    let mut links = Vec::new();
     for entry in fs::read_dir(BPF_MESH_LINKS_DIR)? {
         let entry = entry?;
         let path = entry.path();
@@ -111,33 +126,39 @@ fn get_pinned_iface_links() -> Result<BTreeMap<String, PathBuf>> {
         let Some(iface) = iface_name_from_link_file(&file_name) else {
             continue;
         };
-        links.insert(iface, path);
+        links.push((iface, path));
     }
     Ok(links)
 }
 
 fn iface_name_from_link_file(file_name: &str) -> Option<String> {
-    let iface = file_name
-        .strip_prefix(NODEPORT_LINK_PREFIX)?
-        .strip_suffix(NODEPORT_LINK_SUFFIX)?;
+    let without_prefix = file_name.strip_prefix(NODEPORT_LINK_PREFIX)?;
+    let iface = without_prefix
+        .strip_suffix(NODEPORT_LINK_SUFFIX_INGRESS)
+        .or_else(|| without_prefix.strip_suffix(NODEPORT_LINK_SUFFIX_EGRESS))?;
     if iface.is_empty() {
         return None;
     }
     Some(iface.to_string())
 }
 
-fn ensure_nodeport_attached(iface: &str) -> Result<()> {
-    let pin_path = pin_path_for_iface(iface);
+fn ensure_nodeport_attached(iface: &str, attach_type: TcAttachType) -> Result<()> {
+    let pin_path = pin_path_for_iface(iface, attach_type);
     if pin_path.try_exists()? {
         return Ok(());
     }
 
     let _ = tc::qdisc_add_clsact(iface);
 
-    let mut prog = SchedClassifier::from_pin(BPF_PROGRAM_NODEPORT_INGRESS_TC.path())?;
+    let prog_path = match attach_type {
+        TcAttachType::Ingress => BPF_PROGRAM_NODEPORT_INGRESS_TC.path(),
+        TcAttachType::Egress => BPF_PROGRAM_NODEPORT_EGRESS_TC.path(),
+        TcAttachType::Custom(_) => BPF_PROGRAM_NODEPORT_INGRESS_TC.path(),
+    };
+    let mut prog = SchedClassifier::from_pin(prog_path)?;
 
-    info!(iface = %iface, "attaching nodeport ingress tc program");
-    let link_id = prog.attach(iface, TcAttachType::Ingress)?;
+    info!(iface = %iface, ?attach_type, "attaching nodeport tc program");
+    let link_id = prog.attach(iface, attach_type)?;
     let link = prog.take_link(link_id)?;
     let link: FdLink = link.try_into()?;
     link.pin(pin_path)?;
@@ -145,10 +166,13 @@ fn ensure_nodeport_attached(iface: &str) -> Result<()> {
     Ok(())
 }
 
-fn pin_path_for_iface(iface: &str) -> PathBuf {
-    PathBuf::from(BPF_MESH_LINKS_DIR).join(format!(
-        "{NODEPORT_LINK_PREFIX}{iface}{NODEPORT_LINK_SUFFIX}"
-    ))
+fn pin_path_for_iface(iface: &str, attach_type: TcAttachType) -> PathBuf {
+    let suffix = match attach_type {
+        TcAttachType::Ingress => NODEPORT_LINK_SUFFIX_INGRESS,
+        TcAttachType::Egress => NODEPORT_LINK_SUFFIX_EGRESS,
+        TcAttachType::Custom(_) => NODEPORT_LINK_SUFFIX_INGRESS,
+    };
+    PathBuf::from(BPF_MESH_LINKS_DIR).join(format!("{NODEPORT_LINK_PREFIX}{iface}{suffix}"))
 }
 
 fn unpin_path(path: impl AsRef<Path>) -> Result<()> {

--- a/mesh-cni/src/bpf/service/state.rs
+++ b/mesh-cni/src/bpf/service/state.rs
@@ -8,11 +8,13 @@ use anyhow::anyhow;
 use mesh_cni_ebpf_common::{
     Id,
     service::{
-        EndpointKey, EndpointValue, EndpointValueV4, EndpointValueV6, ServiceKey, ServiceKeyV4,
-        ServiceKeyV6, ServiceValue,
+        EndpointKey, EndpointValue, EndpointValueV4, EndpointValueV6, NodePortFrontendValue,
+        NodePortKey, ServiceKey, ServiceKeyV4, ServiceKeyV6, ServiceValue,
     },
 };
-use mesh_cni_service_bpf_controller::{Error as BpfControllerError, ServiceBpfState};
+use mesh_cni_service_bpf_controller::{
+    Error as BpfControllerError, NodePortMapKey, ServiceBpfState,
+};
 use tracing::warn;
 
 use crate::{Result, bpf::BpfMap};
@@ -205,6 +207,185 @@ where
             map.insert(*k, *v);
         }
         Ok(map)
+    }
+}
+
+struct NodePortShared<N4, N6, P4, P6>
+where
+    N4: BpfMap<Key = NodePortKey, Value = ServiceKeyV4, KeyOutput = NodePortKey>,
+    N6: BpfMap<Key = NodePortKey, Value = ServiceKeyV6, KeyOutput = NodePortKey>,
+    P4: BpfMap<Key = NodePortKey, Value = NodePortFrontendValue, KeyOutput = NodePortKey>,
+    P6: BpfMap<Key = NodePortKey, Value = NodePortFrontendValue, KeyOutput = NodePortKey>,
+{
+    state: Mutex<NodePortStateInner<N4, N6, P4, P6>>,
+}
+
+struct NodePortStateInner<N4, N6, P4, P6>
+where
+    N4: BpfMap<Key = NodePortKey, Value = ServiceKeyV4, KeyOutput = NodePortKey>,
+    N6: BpfMap<Key = NodePortKey, Value = ServiceKeyV6, KeyOutput = NodePortKey>,
+    P4: BpfMap<Key = NodePortKey, Value = NodePortFrontendValue, KeyOutput = NodePortKey>,
+    P6: BpfMap<Key = NodePortKey, Value = NodePortFrontendValue, KeyOutput = NodePortKey>,
+{
+    frontend_map_v4: N4,
+    frontend_map_v6: N6,
+    policy_map_v4: P4,
+    policy_map_v6: P6,
+    frontend_cache_v4: ahash::HashMap<NodePortKey, ServiceKeyV4>,
+    frontend_cache_v6: ahash::HashMap<NodePortKey, ServiceKeyV6>,
+    policy_cache_v4: ahash::HashMap<NodePortKey, NodePortFrontendValue>,
+    policy_cache_v6: ahash::HashMap<NodePortKey, NodePortFrontendValue>,
+}
+
+#[derive(Clone)]
+pub struct NodePortState<N4, N6, P4, P6>
+where
+    N4: BpfMap<Key = NodePortKey, Value = ServiceKeyV4, KeyOutput = NodePortKey>,
+    N6: BpfMap<Key = NodePortKey, Value = ServiceKeyV6, KeyOutput = NodePortKey>,
+    P4: BpfMap<Key = NodePortKey, Value = NodePortFrontendValue, KeyOutput = NodePortKey>,
+    P6: BpfMap<Key = NodePortKey, Value = NodePortFrontendValue, KeyOutput = NodePortKey>,
+{
+    shared: Arc<NodePortShared<N4, N6, P4, P6>>,
+}
+
+impl<N4, N6, P4, P6> NodePortState<N4, N6, P4, P6>
+where
+    N4: BpfMap<Key = NodePortKey, Value = ServiceKeyV4, KeyOutput = NodePortKey>,
+    N6: BpfMap<Key = NodePortKey, Value = ServiceKeyV6, KeyOutput = NodePortKey>,
+    P4: BpfMap<Key = NodePortKey, Value = NodePortFrontendValue, KeyOutput = NodePortKey>,
+    P6: BpfMap<Key = NodePortKey, Value = NodePortFrontendValue, KeyOutput = NodePortKey>,
+{
+    pub fn new(
+        frontend_map_v4: N4,
+        frontend_map_v6: N6,
+        policy_map_v4: P4,
+        policy_map_v6: P6,
+    ) -> Self {
+        let shared = NodePortShared {
+            state: Mutex::new(NodePortStateInner {
+                frontend_map_v4,
+                frontend_map_v6,
+                policy_map_v4,
+                policy_map_v6,
+                frontend_cache_v4: HashMap::default(),
+                frontend_cache_v6: HashMap::default(),
+                policy_cache_v4: HashMap::default(),
+                policy_cache_v6: HashMap::default(),
+            }),
+        };
+        Self {
+            shared: Arc::new(shared),
+        }
+    }
+
+    fn update_frontend(&self, key: NodePortMapKey, value: ServiceKey) -> Result<()> {
+        let mut state = self.shared.state.lock().unwrap();
+        match (key, value) {
+            (NodePortMapKey::V4(frontend), ServiceKey::V4(service_key)) => {
+                state.frontend_map_v4.update(frontend, service_key)?;
+                state.frontend_cache_v4.insert(frontend, service_key);
+                Ok(())
+            }
+            (NodePortMapKey::V6(frontend), ServiceKey::V6(service_key)) => {
+                state.frontend_map_v6.update(frontend, service_key)?;
+                state.frontend_cache_v6.insert(frontend, service_key);
+                Ok(())
+            }
+            _ => Err(anyhow!("nodeport frontend key/value family mismatch")),
+        }
+    }
+
+    fn remove_frontend(&self, key: &NodePortMapKey) -> Result<()> {
+        let mut state = self.shared.state.lock().unwrap();
+        match key {
+            NodePortMapKey::V4(frontend) => {
+                state.frontend_map_v4.delete(frontend)?;
+                state.frontend_cache_v4.remove(frontend);
+            }
+            NodePortMapKey::V6(frontend) => {
+                state.frontend_map_v6.delete(frontend)?;
+                state.frontend_cache_v6.remove(frontend);
+            }
+        }
+        Ok(())
+    }
+
+    fn update_policy(&self, key: NodePortMapKey, value: NodePortFrontendValue) -> Result<()> {
+        let mut state = self.shared.state.lock().unwrap();
+        match key {
+            NodePortMapKey::V4(frontend) => {
+                state.policy_map_v4.update(frontend, value)?;
+                state.policy_cache_v4.insert(frontend, value);
+            }
+            NodePortMapKey::V6(frontend) => {
+                state.policy_map_v6.update(frontend, value)?;
+                state.policy_cache_v6.insert(frontend, value);
+            }
+        }
+        Ok(())
+    }
+
+    fn remove_policy(&self, key: &NodePortMapKey) -> Result<()> {
+        let mut state = self.shared.state.lock().unwrap();
+        match key {
+            NodePortMapKey::V4(frontend) => {
+                state.policy_map_v4.delete(frontend)?;
+                state.policy_cache_v4.remove(frontend);
+            }
+            NodePortMapKey::V6(frontend) => {
+                state.policy_map_v6.delete(frontend)?;
+                state.policy_cache_v6.remove(frontend);
+            }
+        }
+        Ok(())
+    }
+
+    fn frontend_state_from_map(&self) -> Result<ahash::HashMap<NodePortMapKey, ServiceKey>> {
+        let state = self.shared.state.lock().unwrap();
+        let mut map = HashMap::default();
+
+        for (key, value) in state.frontend_map_v4.get_state()? {
+            map.insert(NodePortMapKey::V4(key), ServiceKey::V4(value));
+        }
+        for (key, value) in state.frontend_map_v6.get_state()? {
+            map.insert(NodePortMapKey::V6(key), ServiceKey::V6(value));
+        }
+
+        Ok(map)
+    }
+}
+
+#[derive(Clone)]
+pub struct ControllerServiceBpfState<SE4, SE6, N4, N6, P4, P6>
+where
+    SE4: ServiceEndpointBpfMap<SKey = ServiceKeyV4, EValue = EndpointValueV4>,
+    SE6: ServiceEndpointBpfMap<SKey = ServiceKeyV6, EValue = EndpointValueV6>,
+    N4: BpfMap<Key = NodePortKey, Value = ServiceKeyV4, KeyOutput = NodePortKey>,
+    N6: BpfMap<Key = NodePortKey, Value = ServiceKeyV6, KeyOutput = NodePortKey>,
+    P4: BpfMap<Key = NodePortKey, Value = NodePortFrontendValue, KeyOutput = NodePortKey>,
+    P6: BpfMap<Key = NodePortKey, Value = NodePortFrontendValue, KeyOutput = NodePortKey>,
+{
+    pub service_endpoint_state: ServiceEndpointState<SE4, SE6>,
+    pub nodeport_state: NodePortState<N4, N6, P4, P6>,
+}
+
+impl<SE4, SE6, N4, N6, P4, P6> ControllerServiceBpfState<SE4, SE6, N4, N6, P4, P6>
+where
+    SE4: ServiceEndpointBpfMap<SKey = ServiceKeyV4, EValue = EndpointValueV4>,
+    SE6: ServiceEndpointBpfMap<SKey = ServiceKeyV6, EValue = EndpointValueV6>,
+    N4: BpfMap<Key = NodePortKey, Value = ServiceKeyV4, KeyOutput = NodePortKey>,
+    N6: BpfMap<Key = NodePortKey, Value = ServiceKeyV6, KeyOutput = NodePortKey>,
+    P4: BpfMap<Key = NodePortKey, Value = NodePortFrontendValue, KeyOutput = NodePortKey>,
+    P6: BpfMap<Key = NodePortKey, Value = NodePortFrontendValue, KeyOutput = NodePortKey>,
+{
+    pub fn new(
+        service_endpoint_state: ServiceEndpointState<SE4, SE6>,
+        nodeport_state: NodePortState<N4, N6, P4, P6>,
+    ) -> Self {
+        Self {
+            service_endpoint_state,
+            nodeport_state,
+        }
     }
 }
 
@@ -422,6 +603,129 @@ where
     ) -> std::result::Result<ahash::HashMap<ServiceKey, Vec<EndpointValue>>, BpfControllerError>
     {
         ServiceEndpointState::state_from_map(self)
+            .map_err(|e| BpfControllerError::BpfState(e.to_string()))
+    }
+
+    fn update_nodeport(
+        &self,
+        _key: NodePortMapKey,
+        _value: ServiceKey,
+    ) -> std::result::Result<(), BpfControllerError> {
+        Err(BpfControllerError::Other(
+            "nodeport frontend updates are not supported on ServiceEndpointState".into(),
+        ))
+    }
+
+    fn remove_nodeport(
+        &self,
+        _key: &NodePortMapKey,
+    ) -> std::result::Result<(), BpfControllerError> {
+        Err(BpfControllerError::Other(
+            "nodeport frontend removes are not supported on ServiceEndpointState".into(),
+        ))
+    }
+
+    fn update_nodeport_policy(
+        &self,
+        _key: NodePortMapKey,
+        _value: NodePortFrontendValue,
+    ) -> std::result::Result<(), BpfControllerError> {
+        Err(BpfControllerError::Other(
+            "nodeport policy updates are not supported on ServiceEndpointState".into(),
+        ))
+    }
+
+    fn remove_nodeport_policy(
+        &self,
+        _key: &NodePortMapKey,
+    ) -> std::result::Result<(), BpfControllerError> {
+        Err(BpfControllerError::Other(
+            "nodeport policy removes are not supported on ServiceEndpointState".into(),
+        ))
+    }
+
+    fn nodeport_state(
+        &self,
+    ) -> std::result::Result<ahash::HashMap<NodePortMapKey, ServiceKey>, BpfControllerError> {
+        Ok(HashMap::default())
+    }
+}
+
+impl<SE4, SE6, N4, N6, P4, P6> ServiceBpfState
+    for ControllerServiceBpfState<SE4, SE6, N4, N6, P4, P6>
+where
+    SE4: ServiceEndpointBpfMap<SKey = ServiceKeyV4, EValue = EndpointValueV4>,
+    SE6: ServiceEndpointBpfMap<SKey = ServiceKeyV6, EValue = EndpointValueV6>,
+    N4: BpfMap<Key = NodePortKey, Value = ServiceKeyV4, KeyOutput = NodePortKey>,
+    N6: BpfMap<Key = NodePortKey, Value = ServiceKeyV6, KeyOutput = NodePortKey>,
+    P4: BpfMap<Key = NodePortKey, Value = NodePortFrontendValue, KeyOutput = NodePortKey>,
+    P6: BpfMap<Key = NodePortKey, Value = NodePortFrontendValue, KeyOutput = NodePortKey>,
+{
+    fn update(
+        &self,
+        key: ServiceKey,
+        value: Vec<EndpointValue>,
+    ) -> std::result::Result<(), BpfControllerError> {
+        self.service_endpoint_state
+            .update(key, value)
+            .map_err(|e| BpfControllerError::BpfState(e.to_string()))
+    }
+
+    fn remove(&self, key: &ServiceKey) -> std::result::Result<(), BpfControllerError> {
+        self.service_endpoint_state
+            .remove(key)
+            .map_err(|e| BpfControllerError::BpfState(e.to_string()))
+    }
+
+    fn state(
+        &self,
+    ) -> std::result::Result<ahash::HashMap<ServiceKey, Vec<EndpointValue>>, BpfControllerError>
+    {
+        self.service_endpoint_state
+            .state_from_map()
+            .map_err(|e| BpfControllerError::BpfState(e.to_string()))
+    }
+
+    fn update_nodeport(
+        &self,
+        key: NodePortMapKey,
+        value: ServiceKey,
+    ) -> std::result::Result<(), BpfControllerError> {
+        self.nodeport_state
+            .update_frontend(key, value)
+            .map_err(|e| BpfControllerError::BpfState(e.to_string()))
+    }
+
+    fn remove_nodeport(&self, key: &NodePortMapKey) -> std::result::Result<(), BpfControllerError> {
+        self.nodeport_state
+            .remove_frontend(key)
+            .map_err(|e| BpfControllerError::BpfState(e.to_string()))
+    }
+
+    fn update_nodeport_policy(
+        &self,
+        key: NodePortMapKey,
+        value: NodePortFrontendValue,
+    ) -> std::result::Result<(), BpfControllerError> {
+        self.nodeport_state
+            .update_policy(key, value)
+            .map_err(|e| BpfControllerError::BpfState(e.to_string()))
+    }
+
+    fn remove_nodeport_policy(
+        &self,
+        key: &NodePortMapKey,
+    ) -> std::result::Result<(), BpfControllerError> {
+        self.nodeport_state
+            .remove_policy(key)
+            .map_err(|e| BpfControllerError::BpfState(e.to_string()))
+    }
+
+    fn nodeport_state(
+        &self,
+    ) -> std::result::Result<ahash::HashMap<NodePortMapKey, ServiceKey>, BpfControllerError> {
+        self.nodeport_state
+            .frontend_state_from_map()
             .map_err(|e| BpfControllerError::BpfState(e.to_string()))
     }
 }


### PR DESCRIPTION
This implements initial bpf logic for handling NodePort/LoadBalancer services. This is done via the addition of NodePort maps for node/proto lookups to backend services. Cluster and Local externalTrafficPolicy supported.