### PR TITLE
mesh-cni: add initial nodeport userspace reconciliation

### DIFF
--- a/mesh-cni-api/build.rs
+++ b/mesh-cni-api/build.rs
@@ -70,6 +70,10 @@ fn main() -> anyhow::Result<()> {
             "#[derive(serde::Serialize, serde::Deserialize)]",
         )
         .type_attribute(
+            "service.v1.NodePortService",
+            "#[derive(serde::Serialize, serde::Deserialize)]",
+        )
+        .type_attribute(
             "conntrack.v1.Connection",
             "#[derive(serde::Serialize, serde::Deserialize)]",
         )

--- a/mesh-cni-api/proto/service/v1/service.proto
+++ b/mesh-cni-api/proto/service/v1/service.proto
@@ -4,6 +4,7 @@ package grpc.service.v1;
 
 service Service {
     rpc ListServices(ListServicesRequest) returns (ListServicesReply) {};
+    rpc ListNodePorts(ListNodePortsRequest) returns (ListNodePortsReply) {};
 }
 
 message ListServicesReply {
@@ -20,3 +21,14 @@ message ServiceWithEndpoints {
   repeated string endpoints = 3;
 }
 
+message ListNodePortsReply {
+  repeated NodePortService node_ports = 1;
+}
+
+message ListNodePortsRequest {}
+
+message NodePortService {
+  uint32 node_port = 1;
+  string protocol = 2;
+  string service_endpoint = 3;
+}

--- a/mesh-cni-api/src/tables.rs
+++ b/mesh-cni-api/src/tables.rs
@@ -38,6 +38,26 @@ impl Tabled for crate::service::v1::ServiceWithEndpoints {
     }
 }
 
+impl Tabled for crate::service::v1::NodePortService {
+    const LENGTH: usize = 3;
+
+    fn fields(&self) -> Vec<std::borrow::Cow<'_, str>> {
+        vec![
+            Cow::Owned(self.node_port.to_string()),
+            Cow::Borrowed(&self.protocol),
+            Cow::Borrowed(&self.service_endpoint),
+        ]
+    }
+
+    fn headers() -> Vec<std::borrow::Cow<'static, str>> {
+        vec![
+            Cow::Borrowed("NODEPORT"),
+            Cow::Borrowed("PROTOCOL"),
+            Cow::Borrowed("SERVICE_ENDPOINT"),
+        ]
+    }
+}
+
 impl Tabled for crate::conntrack::v1::Connection {
     const LENGTH: usize = 4;
 

--- a/mesh-cni-cli/src/cli.rs
+++ b/mesh-cni-cli/src/cli.rs
@@ -52,6 +52,11 @@ pub enum ServiceCommands {
         #[arg(short = 'o', long, value_enum, default_value_t = OutputFormat::Table)]
         output: OutputFormat,
     },
+    /// List NodePort to Service mappings
+    ListNodePorts {
+        #[arg(short = 'o', long, value_enum, default_value_t = OutputFormat::Table)]
+        output: OutputFormat,
+    },
 }
 
 #[derive(Clone, Subcommand, Debug)]

--- a/mesh-cni-cli/src/service.rs
+++ b/mesh-cni-cli/src/service.rs
@@ -1,4 +1,6 @@
-use mesh_cni_api::service::v1::{ListServicesRequest, service_client::ServiceClient};
+use mesh_cni_api::service::v1::{
+    ListNodePortsRequest, ListServicesRequest, service_client::ServiceClient,
+};
 use tonic::{Request, transport::Channel};
 
 use crate::{
@@ -11,6 +13,7 @@ pub(crate) async fn run(cmd: ServiceCommands) -> anyhow::Result<()> {
     let client = ServiceClient::connect(MESH_CNI_SOCKET).await?;
     match cmd {
         ServiceCommands::List { from_map, output } => list(client, from_map, output).await?,
+        ServiceCommands::ListNodePorts { output } => list_nodeports(client, output).await?,
     }
     Ok(())
 }
@@ -25,4 +28,15 @@ async fn list(
         .await?;
     let services = response.into_inner().services;
     output::print(services, output)
+}
+
+async fn list_nodeports(
+    mut client: ServiceClient<Channel>,
+    output: OutputFormat,
+) -> anyhow::Result<()> {
+    let response = client
+        .list_node_ports(Request::new(ListNodePortsRequest {}))
+        .await?;
+    let nodeports = response.into_inner().node_ports;
+    output::print(nodeports, output)
 }

--- a/mesh-cni-ebpf-common/src/service.rs
+++ b/mesh-cni-ebpf-common/src/service.rs
@@ -115,3 +115,23 @@ pub struct EndpointValueV6 {
 }
 #[cfg(feature = "user")]
 unsafe impl aya::Pod for EndpointValueV6 {}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+pub struct NodePortKey {
+    pub port: u16,
+    pub protocol: u8,
+    pub _pad: u8,
+}
+#[cfg(feature = "user")]
+unsafe impl aya::Pod for NodePortKey {}
+
+impl NodePortKey {
+    pub const fn new(port: u16, protocol: u8) -> Self {
+        Self {
+            port,
+            protocol,
+            _pad: 0,
+        }
+    }
+}

--- a/mesh-cni-ebpf/src/lib.rs
+++ b/mesh-cni-ebpf/src/lib.rs
@@ -7,7 +7,7 @@ pub mod service;
 
 use aya_ebpf::{
     macros::map,
-    maps::{HashMap, LpmTrie, LruHashMap, lpm_trie::Key as LpmKey},
+    maps::{Array, HashMap, LpmTrie, LruHashMap, lpm_trie::Key as LpmKey},
 };
 use mesh_cni_ebpf_common::{
     IdentityId,
@@ -17,7 +17,8 @@ use mesh_cni_ebpf_common::{
         RulesetId,
     },
     service::{
-        EndpointKey, EndpointValueV4, EndpointValueV6, ServiceKeyV4, ServiceKeyV6, ServiceValue,
+        EndpointKey, EndpointValueV4, EndpointValueV6, NodePortKey, ServiceKeyV4, ServiceKeyV6,
+        ServiceValue,
     },
 };
 
@@ -56,6 +57,16 @@ static ENDPOINTS_V4: HashMap<EndpointKey, EndpointValueV4> = HashMap::with_max_e
 
 #[map(name = "endpoints_v6")]
 static ENDPOINTS_V6: HashMap<EndpointKey, EndpointValueV6> = HashMap::with_max_entries(65535, 0);
+
+#[map(name = "nodeport_iface_indexes")]
+static NODEPORT_IFACE_INDEXES: Array<u32> = Array::with_max_entries(2, 0);
+
+#[map(name = "nodeport_local_addrs_v4")]
+static NODEPORT_LOCAL_ADDRS_V4: HashMap<u32, u8> = HashMap::with_max_entries(65535, 0);
+
+#[map(name = "nodeport_services_v4")]
+static NODEPORT_SERVICES_V4: HashMap<NodePortKey, ServiceKeyV4> =
+    HashMap::with_max_entries(65535, 0);
 
 #[inline]
 fn id_v4(ip: LpmKey<u32>) -> Option<IdentityId> {

--- a/mesh-cni-ebpf/src/service.rs
+++ b/mesh-cni-ebpf/src/service.rs
@@ -1,17 +1,27 @@
 use core::net::Ipv4Addr;
 
 use aya_ebpf::{
-    bindings::{TC_ACT_PIPE, bpf_sock_addr},
-    helpers::generated::bpf_get_prandom_u32,
+    bindings::{BPF_F_INGRESS, TC_ACT_PIPE, bpf_sock_addr},
+    helpers::{bpf_redirect, generated::bpf_get_prandom_u32},
     programs::{SockAddrContext, TcContext},
 };
 use aya_log_ebpf::debug;
-use mesh_cni_ebpf_common::service::{EndpointKey, ServiceKeyV4};
+use mesh_cni_ebpf_common::service::{EndpointKey, NodePortKey, ServiceKeyV4};
+use network_types::{
+    eth::{EthHdr, EtherType},
+    ip::{IpProto, Ipv4Hdr},
+    tcp::TcpHdr,
+    udp::UdpHdr,
+};
 
-use crate::{ENDPOINTS_V4, SERVICES_V4};
+use crate::{
+    ENDPOINTS_V4, NODEPORT_IFACE_INDEXES, NODEPORT_LOCAL_ADDRS_V4, NODEPORT_SERVICES_V4,
+    SERVICES_V4,
+};
 
 const AF_INET: u16 = 2;
 const _AF_INET6: u16 = 10;
+const MESH_HOST_IFACE_KEY: u32 = 0;
 
 // https://docs.ebpf.io/linux/program-type/BPF_PROG_TYPE_CGROUP_SOCK_ADDR/#context
 // Example: https://docs.ebpf.io/linux/program-type/BPF_PROG_TYPE_CGROUP_SOCK_ADDR/#example
@@ -102,7 +112,58 @@ fn get_position(count: u16) -> u16 {
     rand % count
 }
 
+// TODO: implement ipv6
+// TODO: consider sctp?
 #[inline]
-pub fn try_mesh_cni_nodeport_ingress(_ctx: TcContext) -> Result<i32, i32> {
-    Ok(TC_ACT_PIPE)
+pub fn try_mesh_cni_nodeport_ingress(ctx: TcContext) -> Result<i32, i32> {
+    let ethhdr: EthHdr = ctx.load(0).map_err(|_| TC_ACT_PIPE)?;
+    let Ok(ether_type) = ethhdr.ether_type() else {
+        return Ok(TC_ACT_PIPE);
+    };
+    if !matches!(ether_type, EtherType::Ipv4) {
+        return Ok(TC_ACT_PIPE);
+    }
+
+    let ipv4hdr: Ipv4Hdr = ctx.load(EthHdr::LEN).map_err(|_| TC_ACT_PIPE)?;
+    let ihl = ipv4hdr.ihl();
+    let dst_ip = u32::from_be_bytes(ipv4hdr.dst_addr);
+
+    // pass traffic that isn't pointed at IPs assigned to attached ifaces
+    // as this could meant for pods
+    if unsafe { NODEPORT_LOCAL_ADDRS_V4.get(dst_ip) }.is_none() {
+        return Ok(TC_ACT_PIPE);
+    }
+
+    let (dst_port, proto) = match ipv4hdr.proto {
+        IpProto::Tcp => {
+            let tcphdr: TcpHdr = ctx
+                .load(EthHdr::LEN + ihl as usize)
+                .map_err(|_| TC_ACT_PIPE)?;
+            (u16::from_be_bytes(tcphdr.dest), IpProto::Tcp as u8)
+        }
+        IpProto::Udp => {
+            let udphdr: UdpHdr = ctx
+                .load(EthHdr::LEN + ihl as usize)
+                .map_err(|_| TC_ACT_PIPE)?;
+            (u16::from_be_bytes(udphdr.dst), IpProto::Udp as u8)
+        }
+        _ => return Ok(TC_ACT_PIPE),
+    };
+
+    let nodeport_key = NodePortKey::new(dst_port, proto);
+    let Some(service_key) = (unsafe { NODEPORT_SERVICES_V4.get(nodeport_key).copied() }) else {
+        return Ok(TC_ACT_PIPE);
+    };
+    if unsafe { SERVICES_V4.get(service_key).is_none() } {
+        return Ok(TC_ACT_PIPE);
+    };
+
+    let Some(mesh_host_ifindex) = NODEPORT_IFACE_INDEXES.get(MESH_HOST_IFACE_KEY).copied() else {
+        return Ok(TC_ACT_PIPE);
+    };
+    if mesh_host_ifindex == 0 {
+        return Ok(TC_ACT_PIPE);
+    }
+
+    Ok(unsafe { bpf_redirect(mesh_host_ifindex, BPF_F_INGRESS as u64) as i32 })
 }

--- a/mesh-cni-service-bpf-controller/src/controller.rs
+++ b/mesh-cni-service-bpf-controller/src/controller.rs
@@ -5,26 +5,29 @@ use std::{
 };
 
 use ahash::{HashMap, HashSet};
-use k8s_openapi::api::core::v1::Service;
+use k8s_openapi::api::core::v1::{Service, ServiceSpec};
 use kube::{Resource, ResourceExt, runtime::controller::Action};
 use mesh_cni_crds::v1alpha1::meshendpoint::{
     MeshEndpoint, coalesce_mesh_endpoints, generate_mesh_endpoint_spec, service_ips_from_service,
 };
-use mesh_cni_ebpf_common::service::{EndpointValue, ServiceKey};
+use mesh_cni_ebpf_common::{
+    KubeProtocol,
+    service::{EndpointValue, NodePortKey, ServiceKey},
+};
 use mesh_cni_meshendpoint_gen_controller::ANNOTATION_MESH_SERVICE;
 use tracing::{error, info};
 
 use crate::{Context, Error, Result, ServiceBpfState};
 
 const DEFAULT_REQUEUE_DURATION: Duration = Duration::from_secs(300);
-const ERROR_REQUEUE_DURATION: Duration = Duration::from_secs(300);
+const ERROR_REQUEUE_DURATION: Duration = Duration::from_secs(5);
 const MISSING_MESH_ENDPOINT_REQUEUE_DURATION: Duration = Duration::from_secs(5);
 pub const SERVICE_OWNER_LABEL: &str = "kubernetes.io/service-name";
 
-pub async fn reconcile<B>(service: Arc<Service>, ctx: Arc<Context<B>>) -> Result<Action>
-where
-    B: ServiceBpfState,
-{
+pub async fn reconcile<B: ServiceBpfState>(
+    service: Arc<Service>,
+    ctx: Arc<Context<B>>,
+) -> Result<Action> {
     let ns = service
         .namespace()
         .ok_or_else(|| Error::ReconcileMissingPrecondition("missing namespace".into()))?;
@@ -38,13 +41,41 @@ where
     }
 }
 
-pub async fn reconcile_local_service<B>(
+pub async fn reconcile_nodeports<B: ServiceBpfState>(
     service: Arc<Service>,
     ctx: Arc<Context<B>>,
-) -> Result<Action>
-where
-    B: ServiceBpfState,
-{
+) -> Result<Action> {
+    let ns = service
+        .namespace()
+        .ok_or_else(|| Error::ReconcileMissingPrecondition("missing namespace".into()))?;
+    let ns_name = format!("{}/{}", ns, service.name_any());
+    info!("started reconciling NodePort state for Service {}", ns_name);
+
+    inner_reconcile_nodeports(&service, &ctx)?;
+    Ok(Action::await_change())
+}
+
+pub(crate) fn reconcile_all_nodeports<B: ServiceBpfState>(ctx: &Context<B>) -> Result<()> {
+    let desired_nodeports = desired_nodeport_mappings_for_services(&ctx.service_state.state());
+    let current_nodeports = ctx.service_bpf_state.nodeport_state()?;
+    let (keys_to_remove, keys_to_upsert) =
+        diff_global_nodeport_reconcile_actions(&current_nodeports, &desired_nodeports);
+
+    for key in keys_to_remove {
+        ctx.service_bpf_state.remove_nodeport(&key)?;
+    }
+    for (nodeport_key, service_key) in keys_to_upsert {
+        ctx.service_bpf_state
+            .update_nodeport(nodeport_key, service_key)?;
+    }
+
+    Ok(())
+}
+
+pub async fn reconcile_local_service<B: ServiceBpfState>(
+    service: Arc<Service>,
+    ctx: Arc<Context<B>>,
+) -> Result<Action> {
     let desired = generate_desired_service_pairs(&service, &ctx);
     let current = ctx.service_bpf_state.state()?;
     let is_deletion = service.meta().deletion_timestamp.is_some();
@@ -62,13 +93,10 @@ where
     Ok(Action::requeue(DEFAULT_REQUEUE_DURATION))
 }
 
-pub async fn reconcile_multi_cluster_service<B>(
+pub async fn reconcile_multi_cluster_service<B: ServiceBpfState>(
     service: Arc<Service>,
     ctx: Arc<Context<B>>,
-) -> Result<Action>
-where
-    B: ServiceBpfState,
-{
+) -> Result<Action> {
     let desired = generate_service_pairs_from_meps(&service, &ctx);
     let current = ctx.service_bpf_state.state()?;
     let is_deletion = service.meta().deletion_timestamp.is_some();
@@ -103,11 +131,14 @@ where
     Ok(Action::requeue(DEFAULT_REQUEUE_DURATION))
 }
 
-pub fn error_policy<B>(_service: Arc<Service>, error: &Error, _ctx: Arc<Context<B>>) -> Action
-where
-    B: ServiceBpfState,
-{
-    error!("error occurred: {}", error);
+pub fn error_policy<B: ServiceBpfState>(
+    service: Arc<Service>,
+    err: &Error,
+    _ctx: Arc<Context<B>>,
+) -> Action {
+    let ns = service.namespace().unwrap_or_default();
+    let ns_name = format!("{}/{}", ns, service.name_any());
+    error!(%err, "error reconciling {}", ns_name);
     Action::requeue(ERROR_REQUEUE_DURATION)
 }
 
@@ -230,18 +261,189 @@ fn is_meshed_service(service: &Service) -> bool {
     val.to_lowercase() == "true"
 }
 
-#[cfg(test)]
-mod tests {
-    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+fn inner_reconcile_nodeports<B: ServiceBpfState>(
+    service: &Service,
+    ctx: &Context<B>,
+) -> Result<()> {
+    let nodeport_state = ctx.service_bpf_state.nodeport_state()?;
+    let is_deletion = service.meta().deletion_timestamp.is_some();
+    let desired = if !is_deletion && is_nodeport_service_type(service) {
+        desired_nodeport_mappings(service)
+    } else {
+        HashMap::default()
+    };
+    let (keys_to_remove, entries_to_upsert) =
+        diff_nodeport_reconcile_actions(service, &nodeport_state, &desired, is_deletion);
 
-    use ahash::{HashMap, HashSet};
-    use k8s_openapi::api::core::v1::{Service, ServiceSpec};
-    use mesh_cni_ebpf_common::{
-        KubeProtocol,
-        service::{EndpointValue, EndpointValueV4, EndpointValueV6, ServiceKey},
+    for key in keys_to_remove {
+        ctx.service_bpf_state.remove_nodeport(&key)?;
+    }
+    for (nodeport_key, service_key) in entries_to_upsert {
+        ctx.service_bpf_state
+            .update_nodeport(nodeport_key, service_key)?;
+    }
+    Ok(())
+}
+
+fn is_nodeport_service_type(service: &Service) -> bool {
+    service
+        .spec
+        .as_ref()
+        .and_then(|spec| spec.type_.as_deref())
+        .is_some_and(|service_type| matches!(service_type, "LoadBalancer" | "NodePort"))
+}
+
+fn nodeport_owned_keys(
+    service: &Service,
+    current_state: &HashMap<NodePortKey, ServiceKey>,
+) -> HashSet<NodePortKey> {
+    let ips = service_ip_sets(service);
+    current_state
+        .iter()
+        .filter_map(|(nodeport_key, service_key)| {
+            if key_matches_service_ip(service_key, &ips) {
+                Some(*nodeport_key)
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+fn diff_nodeport_reconcile_actions(
+    service: &Service,
+    current_state: &HashMap<NodePortKey, ServiceKey>,
+    desired_state: &HashMap<NodePortKey, ServiceKey>,
+    is_deletion: bool,
+) -> (HashSet<NodePortKey>, Vec<(NodePortKey, ServiceKey)>) {
+    let owned_nodeport_keys = nodeport_owned_keys(service, current_state);
+    if is_deletion {
+        return (owned_nodeport_keys, Vec::new());
+    }
+
+    let keys_to_remove = owned_nodeport_keys
+        .into_iter()
+        .filter(|nodeport_key| !desired_state.contains_key(nodeport_key))
+        .collect();
+
+    let entries_to_upsert = desired_state
+        .iter()
+        .map(|(nodeport_key, service_key)| (*nodeport_key, *service_key))
+        .collect();
+
+    (keys_to_remove, entries_to_upsert)
+}
+
+fn desired_nodeport_mappings_for_services(
+    services: &[Arc<Service>],
+) -> HashMap<NodePortKey, ServiceKey> {
+    let mut desired = HashMap::default();
+    for service in services {
+        if service.meta().deletion_timestamp.is_some() || !is_nodeport_service_type(service) {
+            continue;
+        }
+        for (nodeport_key, service_key) in desired_nodeport_mappings(service) {
+            desired.insert(nodeport_key, service_key);
+        }
+    }
+    desired
+}
+
+fn diff_global_nodeport_reconcile_actions(
+    current_state: &HashMap<NodePortKey, ServiceKey>,
+    desired_state: &HashMap<NodePortKey, ServiceKey>,
+) -> (HashSet<NodePortKey>, Vec<(NodePortKey, ServiceKey)>) {
+    let keys_to_remove = current_state
+        .keys()
+        .filter(|key| !desired_state.contains_key(*key))
+        .copied()
+        .collect();
+    let keys_to_upsert = desired_state
+        .iter()
+        .map(|(nodeport_key, service_key)| (*nodeport_key, *service_key))
+        .collect();
+    (keys_to_remove, keys_to_upsert)
+}
+
+fn desired_nodeport_mappings(service: &Service) -> HashMap<NodePortKey, ServiceKey> {
+    let mut desired = HashMap::default();
+    let Some(cluster_ip) = first_ipv4_cluster_ip(service) else {
+        return desired;
+    };
+    let Some(spec) = &service.spec else {
+        return desired;
     };
 
-    use super::{diff_service_reconcile_actions, should_preserve_current_backends};
+    for (nodeport_key, service_port, protocol) in nodeport_ports(spec) {
+        let service_key = ServiceKey::v4(cluster_ip.to_bits(), service_port, protocol as u8);
+        desired.insert(nodeport_key, service_key);
+    }
+
+    desired
+}
+
+fn nodeport_ports(spec: &ServiceSpec) -> Vec<(NodePortKey, u16, KubeProtocol)> {
+    let mut ports = Vec::new();
+    let Some(service_ports) = &spec.ports else {
+        return ports;
+    };
+
+    for port_spec in service_ports {
+        let Some(node_port) = port_spec
+            .node_port
+            .and_then(|port| u16::try_from(port).ok())
+        else {
+            continue;
+        };
+        let Some(service_port) = u16::try_from(port_spec.port).ok() else {
+            continue;
+        };
+        let protocol = match &port_spec.protocol {
+            Some(protocol) => KubeProtocol::try_from(protocol.as_str()).unwrap_or_default(),
+            None => KubeProtocol::Tcp,
+        };
+        ports.push((
+            NodePortKey::new(node_port, protocol as u8),
+            service_port,
+            protocol,
+        ));
+    }
+    ports
+}
+
+fn first_ipv4_cluster_ip(service: &Service) -> Option<Ipv4Addr> {
+    let spec = service.spec.as_ref()?;
+    let cluster_ips = spec.cluster_ips.as_ref()?;
+    for cluster_ip in cluster_ips {
+        let Ok(ip_addr) = cluster_ip.parse::<IpAddr>() else {
+            continue;
+        };
+        if let IpAddr::V4(ip) = ip_addr {
+            return Some(ip);
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        net::{IpAddr, Ipv4Addr, Ipv6Addr},
+        sync::Arc,
+    };
+
+    use ahash::{HashMap, HashSet};
+    use k8s_openapi::api::core::v1::{Service, ServicePort, ServiceSpec};
+    use mesh_cni_ebpf_common::{
+        KubeProtocol,
+        service::{EndpointValue, EndpointValueV4, EndpointValueV6, NodePortKey, ServiceKey},
+    };
+
+    use super::{
+        desired_nodeport_mappings, desired_nodeport_mappings_for_services,
+        diff_global_nodeport_reconcile_actions, diff_nodeport_reconcile_actions,
+        diff_service_reconcile_actions, should_preserve_current_backends,
+    };
 
     fn service_with_cluster_ips(ips: &[&str]) -> Service {
         Service {
@@ -252,6 +454,32 @@ mod tests {
             },
             spec: Some(ServiceSpec {
                 cluster_ips: Some(ips.iter().map(|ip| (*ip).to_string()).collect()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    fn service_with_nodeports(cluster_ips: &[&str], ports: &[(u16, u16, &str)]) -> Service {
+        let service_ports = ports
+            .iter()
+            .map(|(port, node_port, protocol)| ServicePort {
+                port: i32::from(*port),
+                node_port: Some(i32::from(*node_port)),
+                protocol: Some((*protocol).to_string()),
+                ..Default::default()
+            })
+            .collect();
+        Service {
+            metadata: kube::core::ObjectMeta {
+                namespace: Some("default".to_string()),
+                name: Some("svc".to_string()),
+                ..Default::default()
+            },
+            spec: Some(ServiceSpec {
+                cluster_ips: Some(cluster_ips.iter().map(|ip| (*ip).to_string()).collect()),
+                ports: Some(service_ports),
+                type_: Some(String::from("NodePort")),
                 ..Default::default()
             }),
             ..Default::default()
@@ -391,6 +619,154 @@ mod tests {
         let expected_removes: HashSet<_> = [owned_v4, owned_v6].into_iter().collect();
         assert_eq!(removes, expected_removes);
         assert!(upserts.is_empty());
+    }
+
+    #[test]
+    fn desired_nodeport_mappings_uses_nodeport_key_and_v4_service_key() {
+        let service = service_with_nodeports(&["10.96.0.10"], &[(80, 30080, "TCP")]);
+        let service_key = ServiceKey::v4(
+            Ipv4Addr::new(10, 96, 0, 10).to_bits(),
+            80,
+            KubeProtocol::Tcp as u8,
+        );
+
+        let desired = desired_nodeport_mappings(&service);
+        let nodeport_key = NodePortKey::new(30080, KubeProtocol::Tcp as u8);
+        assert_eq!(desired.get(&nodeport_key), Some(&service_key));
+    }
+
+    #[test]
+    fn nodeport_global_diff_removes_keys_not_in_desired() {
+        let desired_key = NodePortKey::new(30080, KubeProtocol::Tcp as u8);
+        let stale_key = NodePortKey::new(30081, KubeProtocol::Tcp as u8);
+
+        let mut current = HashMap::default();
+        current.insert(
+            desired_key,
+            ServiceKey::v4(
+                Ipv4Addr::new(10, 96, 0, 10).to_bits(),
+                80,
+                KubeProtocol::Tcp as u8,
+            ),
+        );
+        current.insert(
+            stale_key,
+            ServiceKey::v4(
+                Ipv4Addr::new(10, 96, 0, 11).to_bits(),
+                80,
+                KubeProtocol::Tcp as u8,
+            ),
+        );
+
+        let mut desired = HashMap::default();
+        desired.insert(
+            desired_key,
+            ServiceKey::v4(
+                Ipv4Addr::new(10, 96, 0, 10).to_bits(),
+                80,
+                KubeProtocol::Tcp as u8,
+            ),
+        );
+        let (to_remove, to_upsert) = diff_global_nodeport_reconcile_actions(&current, &desired);
+
+        let expected_remove: HashSet<_> = [stale_key].into_iter().collect();
+        assert_eq!(to_remove, expected_remove);
+        assert_eq!(to_upsert.len(), 1);
+        assert_eq!(to_upsert[0].0, desired_key);
+    }
+
+    #[test]
+    fn desired_nodeport_mappings_for_services_skips_non_nodeport_service_types() {
+        let nodeport_service = service_with_nodeports(&["10.96.0.10"], &[(80, 30080, "TCP")]);
+        let mut cluster_ip_service = service_with_nodeports(&["10.96.0.20"], &[(80, 30090, "TCP")]);
+        if let Some(spec) = &mut cluster_ip_service.spec {
+            spec.type_ = Some("ClusterIP".to_string());
+        }
+        let services = vec![Arc::new(nodeport_service), Arc::new(cluster_ip_service)];
+
+        let desired = desired_nodeport_mappings_for_services(&services);
+        let nodeport_key = NodePortKey::new(30080, KubeProtocol::Tcp as u8);
+        let cluster_ip_nodeport_key = NodePortKey::new(30090, KubeProtocol::Tcp as u8);
+
+        assert!(desired.contains_key(&nodeport_key));
+        assert!(!desired.contains_key(&cluster_ip_nodeport_key));
+    }
+
+    #[test]
+    fn nodeport_diff_removes_stale_owned_keys_on_port_change() {
+        let service = service_with_nodeports(&["10.96.0.10"], &[(80, 30081, "TCP")]);
+        let stale_owned = NodePortKey::new(30080, KubeProtocol::Tcp as u8);
+        let desired_owned = NodePortKey::new(30081, KubeProtocol::Tcp as u8);
+        let foreign = NodePortKey::new(30090, KubeProtocol::Tcp as u8);
+
+        let mut current = HashMap::default();
+        current.insert(
+            stale_owned,
+            ServiceKey::v4(
+                Ipv4Addr::new(10, 96, 0, 10).to_bits(),
+                80,
+                KubeProtocol::Tcp as u8,
+            ),
+        );
+        current.insert(
+            foreign,
+            ServiceKey::v4(
+                Ipv4Addr::new(10, 96, 0, 20).to_bits(),
+                80,
+                KubeProtocol::Tcp as u8,
+            ),
+        );
+
+        let desired = desired_nodeport_mappings(&service);
+        let (to_remove, to_upsert) =
+            diff_nodeport_reconcile_actions(&service, &current, &desired, false);
+
+        let expected_remove: HashSet<_> = [stale_owned].into_iter().collect();
+        assert_eq!(to_remove, expected_remove);
+        assert_eq!(to_upsert.len(), 1);
+        assert_eq!(to_upsert[0].0, desired_owned);
+    }
+
+    #[test]
+    fn nodeport_diff_deletion_removes_all_owned_keys() {
+        let service = service_with_nodeports(&["10.96.0.10"], &[(80, 30080, "TCP")]);
+        let key_one = NodePortKey::new(30080, KubeProtocol::Tcp as u8);
+        let key_two = NodePortKey::new(30081, KubeProtocol::Tcp as u8);
+        let foreign = NodePortKey::new(30090, KubeProtocol::Tcp as u8);
+
+        let mut current = HashMap::default();
+        current.insert(
+            key_one,
+            ServiceKey::v4(
+                Ipv4Addr::new(10, 96, 0, 10).to_bits(),
+                80,
+                KubeProtocol::Tcp as u8,
+            ),
+        );
+        current.insert(
+            key_two,
+            ServiceKey::v4(
+                Ipv4Addr::new(10, 96, 0, 10).to_bits(),
+                443,
+                KubeProtocol::Tcp as u8,
+            ),
+        );
+        current.insert(
+            foreign,
+            ServiceKey::v4(
+                Ipv4Addr::new(10, 96, 0, 20).to_bits(),
+                80,
+                KubeProtocol::Tcp as u8,
+            ),
+        );
+
+        let desired = HashMap::default();
+        let (to_remove, to_upsert) =
+            diff_nodeport_reconcile_actions(&service, &current, &desired, true);
+
+        let expected_remove: HashSet<_> = [key_one, key_two].into_iter().collect();
+        assert_eq!(to_remove, expected_remove);
+        assert!(to_upsert.is_empty());
     }
 
     #[test]

--- a/mesh-cni-service-bpf-controller/src/lib.rs
+++ b/mesh-cni-service-bpf-controller/src/lib.rs
@@ -8,11 +8,14 @@ use ahash::HashMap;
 pub use context::Context;
 pub use controller::SERVICE_OWNER_LABEL;
 pub use error::{Error, Result};
-use mesh_cni_ebpf_common::service::{EndpointValue, ServiceKey};
+use mesh_cni_ebpf_common::service::{EndpointValue, NodePortKey, ServiceKey};
 pub use runtime::start_bpf_service_controller;
 
 pub trait ServiceBpfState {
     fn update(&self, key: ServiceKey, value: Vec<EndpointValue>) -> Result<()>;
     fn remove(&self, key: &ServiceKey) -> Result<()>;
     fn state(&self) -> Result<HashMap<ServiceKey, Vec<EndpointValue>>>;
+    fn update_nodeport(&self, key: NodePortKey, service_key: ServiceKey) -> Result<()>;
+    fn remove_nodeport(&self, key: &NodePortKey) -> Result<()>;
+    fn nodeport_state(&self) -> Result<HashMap<NodePortKey, ServiceKey>>;
 }

--- a/mesh-cni-service-bpf-controller/src/runtime.rs
+++ b/mesh-cni-service-bpf-controller/src/runtime.rs
@@ -4,16 +4,16 @@ use futures::StreamExt;
 use k8s_openapi::api::{core::v1::Service, discovery::v1::EndpointSlice};
 use kube::{
     Api, Client, ResourceExt,
-    runtime::{Controller, reflector::ObjectRef},
+    runtime::{Config, Controller, reflector::ObjectRef},
 };
 use mesh_cni_crds::v1alpha1::meshendpoint::MeshEndpoint;
 use mesh_cni_k8s_utils::create_store_and_touched_subscriber;
 use tokio_util::sync::CancellationToken;
-use tracing::info;
+use tracing::{error, info, warn};
 
 use crate::{
     Context, Result, SERVICE_OWNER_LABEL, ServiceBpfState,
-    controller::{error_policy, reconcile},
+    controller::{error_policy, reconcile, reconcile_all_nodeports, reconcile_nodeports},
     utils::shutdown,
 };
 
@@ -40,19 +40,52 @@ where
         Some(Duration::from_secs(30)),
     )
     .await?;
-    let context = Context {
+    let context = Arc::new(Context {
         service_state: service_state.clone(),
         endpoint_slice_state,
         mesh_endpoint_state,
         service_bpf_state,
-    };
+    });
 
+    // initial reconcile against entire state in case of missed deletions while restarting
+    reconcile_all_nodeports(&context)?;
+
+    let svc_config = Config::default().concurrency(10);
+
+    info!("Starting NodePort controller");
+    let nodeport_context = context.clone();
+    tokio::spawn(
+        Controller::for_shared_stream(service_subscriber.clone(), service_state.clone())
+            .with_config(svc_config.clone())
+            .graceful_shutdown_on(shutdown(cancel.clone()))
+            .run(reconcile_nodeports, error_policy::<B>, context.clone())
+            .for_each(move |result| {
+                let nodeport_context = nodeport_context.clone();
+                async move {
+                    match result {
+                        Ok(_) => {}
+                        Err(kube::runtime::controller::Error::ObjectNotFound(obj_ref)) => {
+                            warn!(?obj_ref, "service no longer in local store; running global NodePort cleanup");
+                            if let Err(err) = reconcile_all_nodeports(&nodeport_context) {
+                                error!(%err, "failed to reconcile global NodePort state after ObjectNotFound");
+                            }
+                        }
+                        Err(err) => {
+                            warn!(%err, "NodePort reconcile stream error");
+                        }
+                    }
+                }
+            }),
+    );
+
+    // TODO: consider adding similar ObjectNotFound reconcile as nodeport controller
     info!("Starting Services controller");
     Controller::for_shared_stream(service_subscriber, service_state)
+        .with_config(svc_config)
         .graceful_shutdown_on(shutdown(cancel))
         .owns_shared_stream(endpoint_slice_subscriber)
         .watches_shared_stream(mesh_endpoint_subscriber, meshendpoint_to_service_mapper)
-        .run(reconcile, error_policy::<B>, Arc::new(context))
+        .run(reconcile, error_policy::<B>, context)
         .for_each(|_| futures::future::ready(()))
         .await;
     Ok(())

--- a/mesh-cni/src/agent.rs
+++ b/mesh-cni/src/agent.rs
@@ -62,11 +62,16 @@ pub async fn start(
     info!("loading service/endpoint bpf maps");
     let (service_map_v4, service_map_v6) = bpf::service::load_service_maps()?;
     let (endpoint_map_v4, endpoint_map_v6) = bpf::service::load_endpoint_maps()?;
+    let nodeport_service_map = bpf::service::load_nodeport_service_map()?;
 
     info!("starting kube service service");
     let service_endpoint_v4 = ServiceEndpoint::new(service_map_v4, endpoint_map_v4);
     let service_endpoint_v6 = ServiceEndpoint::new(service_map_v6, endpoint_map_v6);
-    let state = ServiceEndpointState::new(service_endpoint_v4, service_endpoint_v6);
+    let state = ServiceEndpointState::new(
+        service_endpoint_v4,
+        service_endpoint_v6,
+        nodeport_service_map,
+    );
     bpf::service::run(
         kube_client.clone(),
         state.clone(),

--- a/mesh-cni/src/bpf/mod.rs
+++ b/mesh-cni/src/bpf/mod.rs
@@ -34,6 +34,10 @@ pub const BPF_MAP_SERVICES_V4: BpfNamePath = BpfNamePath::Map("services_v4");
 pub const BPF_MAP_SERVICES_V6: BpfNamePath = BpfNamePath::Map("services_v6");
 pub const BPF_MAP_ENDPOINTS_V4: BpfNamePath = BpfNamePath::Map("endpoints_v4");
 pub const BPF_MAP_ENDPOINTS_V6: BpfNamePath = BpfNamePath::Map("endpoints_v6");
+pub const BPF_MAP_NODEPORT_IFACE_INDEXES: BpfNamePath = BpfNamePath::Map("nodeport_iface_indexes");
+pub const BPF_MAP_NODEPORT_LOCAL_ADDRS_V4: BpfNamePath =
+    BpfNamePath::Map("nodeport_local_addrs_v4");
+pub const BPF_MAP_NODEPORT_SERVICES_V4: BpfNamePath = BpfNamePath::Map("nodeport_services_v4");
 pub const BPF_MAP_POLICY_INDEX: BpfNamePath = BpfNamePath::Map("policy_index");
 pub const BPF_MAP_POLICY_RULESET: BpfNamePath = BpfNamePath::Map("policy_ruleset");
 pub const BPF_MAP_POLICY_CIDR_V4: BpfNamePath = BpfNamePath::Map("policy_cidr_v4");
@@ -54,11 +58,14 @@ pub(crate) const POLICY_MAPS_LIST: [BpfNamePath; 7] = [
     BPF_MAP_POLICY_CIDR_V6,
 ];
 
-pub(crate) const SERVICE_MAPS_LIST: [BpfNamePath; 4] = [
+pub(crate) const SERVICE_MAPS_LIST: [BpfNamePath; 7] = [
     BPF_MAP_SERVICES_V4,
     BPF_MAP_SERVICES_V6,
     BPF_MAP_ENDPOINTS_V4,
     BPF_MAP_ENDPOINTS_V6,
+    BPF_MAP_NODEPORT_IFACE_INDEXES,
+    BPF_MAP_NODEPORT_LOCAL_ADDRS_V4,
+    BPF_MAP_NODEPORT_SERVICES_V4,
 ];
 
 pub(crate) const PROG_LIST: [BpfNamePath; 4] = [

--- a/mesh-cni/src/bpf/service/mod.rs
+++ b/mesh-cni/src/bpf/service/mod.rs
@@ -4,7 +4,8 @@ mod state;
 use aya::maps::{HashMap, Map, MapData};
 use kube::Client;
 use mesh_cni_ebpf_common::service::{
-    EndpointKey, EndpointValueV4, EndpointValueV6, ServiceKeyV4, ServiceKeyV6, ServiceValue,
+    EndpointKey, EndpointValueV4, EndpointValueV6, NodePortKey, ServiceKeyV4, ServiceKeyV6,
+    ServiceValue,
 };
 use mesh_cni_service_bpf_controller::start_bpf_service_controller;
 pub use state::{ServiceEndpoint, ServiceEndpointBpfMap, ServiceEndpointState};
@@ -13,17 +14,21 @@ use tracing::info;
 
 use crate::{
     Result,
-    bpf::{BPF_MAP_ENDPOINTS_V4, BPF_MAP_ENDPOINTS_V6, BPF_MAP_SERVICES_V4, BPF_MAP_SERVICES_V6},
+    bpf::{
+        BPF_MAP_ENDPOINTS_V4, BPF_MAP_ENDPOINTS_V6, BPF_MAP_NODEPORT_SERVICES_V4,
+        BPF_MAP_SERVICES_V4, BPF_MAP_SERVICES_V6,
+    },
     config::NodePortSettings,
 };
 type ServiceMapV4 = HashMap<MapData, ServiceKeyV4, ServiceValue>;
 type ServiceMapV6 = HashMap<MapData, ServiceKeyV6, ServiceValue>;
 type EndpointMapV4 = HashMap<MapData, EndpointKey, EndpointValueV4>;
 type EndpointMapV6 = HashMap<MapData, EndpointKey, EndpointValueV6>;
+type NodePortServiceMapV4 = HashMap<MapData, NodePortKey, ServiceKeyV4>;
 
-pub async fn run<SE4, SE6>(
+pub async fn run<SE4, SE6, NP>(
     kube_client: Client,
-    service_bpf_state: ServiceEndpointState<SE4, SE6>,
+    service_bpf_state: ServiceEndpointState<SE4, SE6, NP>,
     node_port_settings: NodePortSettings,
     cancel: CancellationToken,
 ) -> Result<()>
@@ -36,12 +41,17 @@ where
         + Send
         + Sync
         + 'static,
+    NP: crate::bpf::BpfMap<Key = NodePortKey, Value = ServiceKeyV4, KeyOutput = NodePortKey>
+        + Send
+        + Sync
+        + 'static,
 {
     let service_controller =
         start_bpf_service_controller(kube_client, service_bpf_state, cancel.child_token());
 
     tokio::spawn(service_controller);
-    nodeport_iface::start_nodeport_iface_reconciler(node_port_settings, cancel.child_token())?;
+    nodeport_iface::start_nodeport_iface_reconciler(node_port_settings, cancel.child_token())
+        .await?;
 
     Ok(())
 }
@@ -72,4 +82,12 @@ pub fn load_endpoint_maps() -> Result<(EndpointMapV4, EndpointMapV6)> {
     let ipv6_map = ipv6_map.try_into()?;
 
     Ok((ipv4_map, ipv6_map))
+}
+
+pub fn load_nodeport_service_map() -> Result<NodePortServiceMapV4> {
+    info!("loading nodeport service map");
+    let map = MapData::from_pin(BPF_MAP_NODEPORT_SERVICES_V4.path())?;
+    let map = Map::HashMap(map);
+    let map = map.try_into()?;
+    Ok(map)
 }

--- a/mesh-cni/src/bpf/service/nodeport_iface.rs
+++ b/mesh-cni/src/bpf/service/nodeport_iface.rs
@@ -1,32 +1,46 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
     fs,
+    net::IpAddr,
     path::{Path, PathBuf},
     time::Duration,
 };
 
 use anyhow::anyhow;
-use aya::programs::{
-    SchedClassifier, TcAttachType,
-    links::{FdLink, LinkError, PinnedLink},
-    tc,
+use aya::{
+    maps::{Array, HashMap as AyaHashMap, Map, MapData},
+    programs::{
+        SchedClassifier, TcAttachType,
+        links::{FdLink, LinkError, PinnedLink},
+        tc,
+    },
 };
 use regex::Regex;
+use rtnetlink::{Handle, packet_route::address::AddressAttribute};
+use tokio_stream::StreamExt;
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
 use crate::{
     Result,
-    bpf::{BPF_MESH_LINKS_DIR, BPF_PROGRAM_NODEPORT_INGRESS_TC},
+    bpf::{
+        BPF_MAP_NODEPORT_IFACE_INDEXES, BPF_MAP_NODEPORT_LOCAL_ADDRS_V4, BPF_MESH_LINKS_DIR,
+        BPF_PROGRAM_NODEPORT_INGRESS_TC,
+    },
     config::NodePortSettings,
 };
 
 const HOST_NET_IFACE_DIR: &str = "/sys/class/net";
+const HOST_IFACE_INDEX_FILE: &str = "ifindex";
+const MESH_HOST_IFACE: &str = "mesh_host";
+const MESH_POD_IFACE: &str = "mesh_pod";
+const MESH_HOST_IFACE_KEY: u32 = 0;
+const MESH_POD_IFACE_KEY: u32 = 1;
 const NODEPORT_LINK_PREFIX: &str = "mesh_cni_nodeport_";
 const NODEPORT_LINK_SUFFIX: &str = "_ingress";
 const RECONCILE_INTERVAL: Duration = Duration::from_secs(30);
 
-pub fn start_nodeport_iface_reconciler(
+pub async fn start_nodeport_iface_reconciler(
     node_port_settings: NodePortSettings,
     cancel: CancellationToken,
 ) -> Result<()> {
@@ -42,12 +56,19 @@ pub fn start_nodeport_iface_reconciler(
         "starting nodeport interface reconciler"
     );
 
+    let (conn, handle, _) = rtnetlink::new_connection()?;
+    tokio::spawn(conn);
+
+    reconcile(&iface_regex, &handle).await?;
+
     let mut interval = tokio::time::interval(RECONCILE_INTERVAL);
+    let handle = handle.clone();
 
     tokio::spawn(async move {
+        interval.tick().await;
         // TODO: investigate if this can event driven using rtnetlink
         loop {
-            if let Err(err) = reconcile(&iface_regex) {
+            if let Err(err) = reconcile(&iface_regex, &handle).await {
                 warn!(%err, "nodeport interface reconciliation failed");
             }
             tokio::select! {
@@ -63,8 +84,13 @@ pub fn start_nodeport_iface_reconciler(
     Ok(())
 }
 
-fn reconcile(iface_regex: &Regex) -> Result<()> {
+async fn reconcile(iface_regex: &Regex, handle: &Handle) -> Result<()> {
+    // in case mesh owned interfaces are deleted and get recreated
+    // we need to update the map with new values
+    reconcile_mesh_iface_indexes()?;
+
     let desired_ifaces = get_matching_ifaces(iface_regex)?;
+    reconcile_local_addrs_v4(&desired_ifaces, handle).await?;
     let current_links = get_pinned_iface_links()?;
 
     for iface in &desired_ifaces {
@@ -77,13 +103,108 @@ fn reconcile(iface_regex: &Regex) -> Result<()> {
         }
         unpin_path(&link_path)?;
         info!(
-            iface = %iface,
+            %iface,
             path = %link_path.display(),
             "removed stale nodeport ingress link"
         );
     }
 
     Ok(())
+}
+
+async fn reconcile_local_addrs_v4(
+    desired_ifaces: &BTreeSet<String>,
+    handle: &Handle,
+) -> Result<()> {
+    let desired_addrs = local_addrs_v4_for_ifaces(desired_ifaces, handle).await?;
+    let mut local_addrs_map = load_nodeport_local_addrs_map()?;
+    let current_addrs = local_addrs_v4_from_map(&local_addrs_map)?;
+
+    for stale_ip in current_addrs.difference(&desired_addrs) {
+        local_addrs_map.remove(stale_ip)?;
+    }
+    for local_ip in desired_addrs.difference(&current_addrs) {
+        local_addrs_map.insert(*local_ip, 1, 0)?;
+    }
+
+    Ok(())
+}
+
+fn reconcile_mesh_iface_indexes() -> Result<()> {
+    let mut iface_indexes = load_nodeport_iface_indexes()?;
+    let mesh_host_ifindex = iface_index(MESH_HOST_IFACE)?;
+    let mesh_pod_ifindex = iface_index(MESH_POD_IFACE)?;
+    iface_indexes.set(MESH_HOST_IFACE_KEY, mesh_host_ifindex, 0)?;
+    iface_indexes.set(MESH_POD_IFACE_KEY, mesh_pod_ifindex, 0)?;
+    Ok(())
+}
+
+fn load_nodeport_iface_indexes() -> Result<Array<MapData, u32>> {
+    let map = MapData::from_pin(BPF_MAP_NODEPORT_IFACE_INDEXES.path())?;
+    let map = Map::Array(map);
+    let map = map.try_into()?;
+    Ok(map)
+}
+
+fn load_nodeport_local_addrs_map() -> Result<AyaHashMap<MapData, u32, u8>> {
+    let map = MapData::from_pin(BPF_MAP_NODEPORT_LOCAL_ADDRS_V4.path())?;
+    let map = Map::HashMap(map);
+    let map = map.try_into()?;
+    Ok(map)
+}
+
+fn local_addrs_v4_from_map(map: &AyaHashMap<MapData, u32, u8>) -> Result<BTreeSet<u32>> {
+    let mut addrs = BTreeSet::new();
+    for entry in map.iter() {
+        let (ip, _) = entry?;
+        addrs.insert(ip);
+    }
+    Ok(addrs)
+}
+
+async fn local_addrs_v4_for_ifaces(
+    desired_ifaces: &BTreeSet<String>,
+    handle: &Handle,
+) -> Result<BTreeSet<u32>> {
+    let mut addrs = BTreeSet::new();
+    for iface in desired_ifaces {
+        let mut links = handle
+            .clone()
+            .link()
+            .get()
+            .match_name(iface.clone())
+            .execute();
+        let Some(link) = links.try_next().await? else {
+            warn!(%iface, "failed to find interface while reconciling nodeport local addrs");
+            continue;
+        };
+        let mut addresses = handle
+            .clone()
+            .address()
+            .get()
+            .set_link_index_filter(link.header.index)
+            .execute();
+        while let Some(msg) = addresses.try_next().await? {
+            for attr in msg.attributes {
+                if let AddressAttribute::Local(IpAddr::V4(ip)) = attr {
+                    addrs.insert(u32::from(ip));
+                }
+            }
+        }
+    }
+    Ok(addrs)
+}
+
+fn iface_index(iface: &str) -> Result<u32> {
+    let path = PathBuf::from(HOST_NET_IFACE_DIR)
+        .join(iface)
+        .join(HOST_IFACE_INDEX_FILE);
+    let ifindex = fs::read_to_string(&path)?;
+    let ifindex = ifindex
+        .trim()
+        .parse::<u32>()
+        .map_err(|e| anyhow!("invalid ifindex for {} at {}: {}", iface, path.display(), e))?;
+    Ok(ifindex)
 }
 
 fn get_matching_ifaces(iface_regex: &Regex) -> Result<BTreeSet<String>> {
@@ -136,7 +257,7 @@ fn ensure_nodeport_attached(iface: &str) -> Result<()> {
 
     let mut prog = SchedClassifier::from_pin(BPF_PROGRAM_NODEPORT_INGRESS_TC.path())?;
 
-    info!(iface = %iface, "attaching nodeport ingress tc program");
+    info!(%iface, "attaching nodeport ingress tc program");
     let link_id = prog.attach(iface, TcAttachType::Ingress)?;
     let link = prog.take_link(link_id)?;
     let link: FdLink = link.try_into()?;

--- a/mesh-cni/src/bpf/service/state.rs
+++ b/mesh-cni/src/bpf/service/state.rs
@@ -5,17 +5,30 @@ use std::{
 
 use ahash::{HashMap, HashMapExt};
 use anyhow::anyhow;
+use aya::maps::MapError;
 use mesh_cni_ebpf_common::{
     Id,
     service::{
-        EndpointKey, EndpointValue, EndpointValueV4, EndpointValueV6, ServiceKey, ServiceKeyV4,
-        ServiceKeyV6, ServiceValue,
+        EndpointKey, EndpointValue, EndpointValueV4, EndpointValueV6, NodePortKey, ServiceKey,
+        ServiceKeyV4, ServiceKeyV6, ServiceValue,
     },
 };
 use mesh_cni_service_bpf_controller::{Error as BpfControllerError, ServiceBpfState};
 use tracing::warn;
 
 use crate::{Result, bpf::BpfMap};
+
+fn is_map_not_found_error(err: &anyhow::Error) -> bool {
+    err.downcast_ref::<MapError>()
+        .is_some_and(|map_err| match map_err {
+            MapError::KeyNotFound | MapError::ElementNotFound => true,
+            MapError::SyscallError(sys_err) => {
+                sys_err.io_error.raw_os_error() == Some(libc::ENOENT)
+            }
+            MapError::IoError(io_err) => io_err.raw_os_error() == Some(libc::ENOENT),
+            _ => false,
+        })
+}
 
 pub trait ServiceEndpointBpfMap {
     type SKey: std::hash::Hash + std::cmp::Eq + Clone;
@@ -208,36 +221,42 @@ where
     }
 }
 
-struct Shared<SE4, SE6>
+struct Shared<SE4, SE6, NP>
 where
     SE4: ServiceEndpointBpfMap,
     SE6: ServiceEndpointBpfMap,
+    NP: BpfMap<Key = NodePortKey, Value = ServiceKeyV4, KeyOutput = NodePortKey>,
 {
-    state: Mutex<State<SE4, SE6>>,
+    state: Mutex<State<SE4, SE6, NP>>,
 }
 
-struct State<SE4, SE6>
+struct State<SE4, SE6, NP>
 where
     SE4: ServiceEndpointBpfMap,
     SE6: ServiceEndpointBpfMap,
+    NP: BpfMap<Key = NodePortKey, Value = ServiceKeyV4, KeyOutput = NodePortKey>,
 {
     service_endpoint_v4: SE4,
     service_endpoint_v6: SE6,
+    nodeport_cache: ahash::HashMap<NodePortKey, ServiceKeyV4>,
+    nodeport_map: NP,
     id: Id,
 }
 
-pub struct ServiceEndpointState<SE4, SE6>
+pub struct ServiceEndpointState<SE4, SE6, NP>
 where
     SE4: ServiceEndpointBpfMap<SKey = ServiceKeyV4, EValue = EndpointValueV4>,
     SE6: ServiceEndpointBpfMap<SKey = ServiceKeyV6, EValue = EndpointValueV6>,
+    NP: BpfMap<Key = NodePortKey, Value = ServiceKeyV4, KeyOutput = NodePortKey>,
 {
-    shared: Arc<Shared<SE4, SE6>>,
+    shared: Arc<Shared<SE4, SE6, NP>>,
 }
 
-impl<SE4, SE6> Clone for ServiceEndpointState<SE4, SE6>
+impl<SE4, SE6, NP> Clone for ServiceEndpointState<SE4, SE6, NP>
 where
     SE4: ServiceEndpointBpfMap<SKey = ServiceKeyV4, EValue = EndpointValueV4>,
     SE6: ServiceEndpointBpfMap<SKey = ServiceKeyV6, EValue = EndpointValueV6>,
+    NP: BpfMap<Key = NodePortKey, Value = ServiceKeyV4, KeyOutput = NodePortKey>,
 {
     fn clone(&self) -> Self {
         Self {
@@ -246,15 +265,22 @@ where
     }
 }
 
-impl<SE4, SE6> ServiceEndpointState<SE4, SE6>
+impl<SE4, SE6, NP> ServiceEndpointState<SE4, SE6, NP>
 where
     SE4: ServiceEndpointBpfMap<SKey = ServiceKeyV4, EValue = EndpointValueV4>,
     SE6: ServiceEndpointBpfMap<SKey = ServiceKeyV6, EValue = EndpointValueV6>,
+    NP: BpfMap<Key = NodePortKey, Value = ServiceKeyV4, KeyOutput = NodePortKey>,
 {
-    pub(crate) fn new(service_endpoint_v4: SE4, service_endpoint_v6: SE6) -> Self {
+    pub(crate) fn new(
+        service_endpoint_v4: SE4,
+        service_endpoint_v6: SE6,
+        nodeport_map: NP,
+    ) -> Self {
         let state = State {
             service_endpoint_v4,
             service_endpoint_v6,
+            nodeport_cache: ahash::HashMap::default(),
+            nodeport_map,
             id: 128,
         };
 
@@ -318,6 +344,56 @@ where
             }
         }
         Ok(())
+    }
+
+    pub(crate) fn update_nodeport(&self, key: NodePortKey, service_key: ServiceKey) -> Result<()> {
+        let mut state = self.shared.state.lock().unwrap();
+        let service_key_v4 = match service_key {
+            ServiceKey::V4(service_key_v4) => service_key_v4,
+            ServiceKey::V6(_) => {
+                return Err(anyhow!("nodeport map only supports ipv4 service keys"));
+            }
+        };
+        state.nodeport_map.update(key, service_key_v4)?;
+        state.nodeport_cache.insert(key, service_key_v4);
+        Ok(())
+    }
+
+    pub(crate) fn remove_nodeport(&self, key: &NodePortKey) -> Result<()> {
+        let mut state = self.shared.state.lock().unwrap();
+        match state.nodeport_map.delete(key) {
+            Ok(()) => {
+                state.nodeport_cache.remove(key);
+                Ok(())
+            }
+            Err(err) if is_map_not_found_error(&err) => {
+                state.nodeport_cache.remove(key);
+                Ok(())
+            }
+            Err(err) => Err(err),
+        }
+    }
+
+    pub(crate) fn nodeport_state_from_map(
+        &self,
+    ) -> Result<ahash::HashMap<NodePortKey, ServiceKey>> {
+        let state = self.shared.state.lock().unwrap();
+        let map = state.nodeport_map.get_state()?;
+        Ok(map
+            .into_iter()
+            .map(|(nodeport_key, service_key)| (nodeport_key, ServiceKey::V4(service_key)))
+            .collect())
+    }
+
+    pub(crate) fn nodeport_state_from_cache(
+        &self,
+    ) -> Result<ahash::HashMap<NodePortKey, ServiceKey>> {
+        let state = self.shared.state.lock().unwrap();
+        Ok(state
+            .nodeport_cache
+            .iter()
+            .map(|(nodeport_key, service_key)| (*nodeport_key, ServiceKey::V4(*service_key)))
+            .collect())
     }
 
     pub(crate) fn state_from_cache(
@@ -398,10 +474,11 @@ where
     }
 }
 
-impl<SE4, SE6> ServiceBpfState for ServiceEndpointState<SE4, SE6>
+impl<SE4, SE6, NP> ServiceBpfState for ServiceEndpointState<SE4, SE6, NP>
 where
     SE4: ServiceEndpointBpfMap<SKey = ServiceKeyV4, EValue = EndpointValueV4>,
     SE6: ServiceEndpointBpfMap<SKey = ServiceKeyV6, EValue = EndpointValueV6>,
+    NP: BpfMap<Key = NodePortKey, Value = ServiceKeyV4, KeyOutput = NodePortKey>,
 {
     fn update(
         &self,
@@ -424,6 +501,27 @@ where
         ServiceEndpointState::state_from_map(self)
             .map_err(|e| BpfControllerError::BpfState(e.to_string()))
     }
+
+    fn update_nodeport(
+        &self,
+        key: NodePortKey,
+        service_key: ServiceKey,
+    ) -> std::result::Result<(), BpfControllerError> {
+        ServiceEndpointState::update_nodeport(self, key, service_key)
+            .map_err(|e| BpfControllerError::BpfState(e.to_string()))
+    }
+
+    fn remove_nodeport(&self, key: &NodePortKey) -> std::result::Result<(), BpfControllerError> {
+        ServiceEndpointState::remove_nodeport(self, key)
+            .map_err(|e| BpfControllerError::BpfState(e.to_string()))
+    }
+
+    fn nodeport_state(
+        &self,
+    ) -> std::result::Result<ahash::HashMap<NodePortKey, ServiceKey>, BpfControllerError> {
+        ServiceEndpointState::nodeport_state_from_map(self)
+            .map_err(|e| BpfControllerError::BpfState(e.to_string()))
+    }
 }
 
 #[cfg(test)]
@@ -444,6 +542,27 @@ mod test {
         let service_map: HashMap<ServiceKeyV4, ServiceValue> = HashMap::default();
         let endpoint_map: HashMap<EndpointKey, EndpointValueV4> = HashMap::default();
         ServiceEndpoint::new(service_map, endpoint_map)
+    }
+
+    fn new_service_endpoint_state() -> ServiceEndpointState<
+        ServiceEndpoint<
+            HashMap<ServiceKeyV4, ServiceValue>,
+            HashMap<EndpointKey, EndpointValueV4>,
+            ServiceKeyV4,
+            EndpointValueV4,
+        >,
+        ServiceEndpoint<
+            HashMap<ServiceKeyV6, ServiceValue>,
+            HashMap<EndpointKey, EndpointValueV6>,
+            ServiceKeyV6,
+            EndpointValueV6,
+        >,
+        HashMap<NodePortKey, ServiceKeyV4>,
+    > {
+        let service_v4 = ServiceEndpoint::new(HashMap::default(), HashMap::default());
+        let service_v6 = ServiceEndpoint::new(HashMap::default(), HashMap::default());
+        let nodeport = HashMap::default();
+        ServiceEndpointState::new(service_v4, service_v6, nodeport)
     }
 
     #[test]
@@ -517,6 +636,36 @@ mod test {
             1
         );
 
+        Ok(())
+    }
+
+    #[test]
+    fn update_nodeport_uses_service_value() -> crate::Result<()> {
+        let state = new_service_endpoint_state();
+        let service_key = ServiceKey::v4(
+            Ipv4Addr::new(10, 96, 0, 10).to_bits(),
+            80,
+            KubeProtocol::Tcp as u8,
+        );
+        let endpoint = EndpointValue::V4(EndpointValueV4 {
+            ip: Ipv4Addr::new(10, 0, 0, 2).to_bits(),
+            port: 8080,
+            _protocol: KubeProtocol::Tcp as u8,
+        });
+        state.update(service_key, vec![endpoint])?;
+
+        let nodeport_key = NodePortKey::new(30080, KubeProtocol::Tcp as u8);
+        state.update_nodeport(
+            nodeport_key,
+            ServiceKey::v4(
+                Ipv4Addr::new(10, 96, 0, 10).to_bits(),
+                80,
+                KubeProtocol::Tcp as u8,
+            ),
+        )?;
+        let nodeport_state = state.nodeport_state_from_map()?;
+
+        assert!(nodeport_state.contains_key(&nodeport_key));
         Ok(())
     }
 }

--- a/mesh-cni/src/http/grpc/service.rs
+++ b/mesh-cni/src/http/grpc/service.rs
@@ -1,22 +1,32 @@
 use std::net::{Ipv4Addr, Ipv6Addr};
 
 use mesh_cni_api::service::v1::{
-    ListServicesReply, ListServicesRequest, ServiceWithEndpoints,
+    ListNodePortsReply, ListNodePortsRequest, ListServicesReply, ListServicesRequest,
+    NodePortService, ServiceWithEndpoints,
     service_server::{Service as ServiceApi, ServiceServer},
 };
 use mesh_cni_ebpf_common::{
     KubeProtocol,
-    service::{EndpointValue, EndpointValueV4, EndpointValueV6, ServiceKeyV4, ServiceKeyV6},
+    service::{
+        EndpointValue, EndpointValueV4, EndpointValueV6, NodePortKey, ServiceKey, ServiceKeyV4,
+        ServiceKeyV6,
+    },
 };
 use tonic::{Request, Response, Status};
 use tracing::info;
 
-use crate::bpf::service::{ServiceEndpointBpfMap, ServiceEndpointState};
+use crate::bpf::{
+    BpfMap,
+    service::{ServiceEndpointBpfMap, ServiceEndpointState},
+};
 
-pub fn server<SE4, SE6>(state: ServiceEndpointState<SE4, SE6>) -> ServiceServer<Server<SE4, SE6>>
+pub fn server<SE4, SE6, NP>(
+    state: ServiceEndpointState<SE4, SE6, NP>,
+) -> ServiceServer<Server<SE4, SE6, NP>>
 where
-    SE4: ServiceEndpointBpfMap<SKey = ServiceKeyV4, EValue = EndpointValueV4>,
-    SE6: ServiceEndpointBpfMap<SKey = ServiceKeyV6, EValue = EndpointValueV6>,
+    SE4: ServiceEndpointBpfMap<SKey = ServiceKeyV4, EValue = EndpointValueV4> + Send + 'static,
+    SE6: ServiceEndpointBpfMap<SKey = ServiceKeyV6, EValue = EndpointValueV6> + Send + 'static,
+    NP: BpfMap<Key = NodePortKey, Value = ServiceKeyV4, KeyOutput = NodePortKey> + Send + 'static,
 {
     info!("creating new service state");
     let server = Server::new(state);
@@ -24,29 +34,32 @@ where
 }
 
 #[derive(Clone)]
-pub struct Server<SE4, SE6>
+pub struct Server<SE4, SE6, NP>
 where
     SE4: ServiceEndpointBpfMap<SKey = ServiceKeyV4, EValue = EndpointValueV4>,
     SE6: ServiceEndpointBpfMap<SKey = ServiceKeyV6, EValue = EndpointValueV6>,
+    NP: BpfMap<Key = NodePortKey, Value = ServiceKeyV4, KeyOutput = NodePortKey>,
 {
-    state: ServiceEndpointState<SE4, SE6>,
+    state: ServiceEndpointState<SE4, SE6, NP>,
 }
 
-impl<SE4, SE6> Server<SE4, SE6>
+impl<SE4, SE6, NP> Server<SE4, SE6, NP>
 where
     SE4: ServiceEndpointBpfMap<SKey = ServiceKeyV4, EValue = EndpointValueV4>,
     SE6: ServiceEndpointBpfMap<SKey = ServiceKeyV6, EValue = EndpointValueV6>,
+    NP: BpfMap<Key = NodePortKey, Value = ServiceKeyV4, KeyOutput = NodePortKey>,
 {
-    pub fn new(state: ServiceEndpointState<SE4, SE6>) -> Self {
+    pub fn new(state: ServiceEndpointState<SE4, SE6, NP>) -> Self {
         Self { state }
     }
 }
 
 #[tonic::async_trait]
-impl<SE4, SE6> ServiceApi for Server<SE4, SE6>
+impl<SE4, SE6, NP> ServiceApi for Server<SE4, SE6, NP>
 where
     SE4: ServiceEndpointBpfMap<SKey = ServiceKeyV4, EValue = EndpointValueV4> + Send + 'static,
     SE6: ServiceEndpointBpfMap<SKey = ServiceKeyV6, EValue = EndpointValueV6> + Send + 'static,
+    NP: BpfMap<Key = NodePortKey, Value = ServiceKeyV4, KeyOutput = NodePortKey> + Send + 'static,
 {
     async fn list_services(
         &self,
@@ -65,7 +78,7 @@ where
         let mut services = vec![];
         for (k, v) in state.iter() {
             let (service_endpoint, protocol, endpoints) = match k {
-                mesh_cni_ebpf_common::service::ServiceKey::V4(service_key_v4) => {
+                ServiceKey::V4(service_key_v4) => {
                     let service_ip = Ipv4Addr::from_bits(service_key_v4.ip);
                     let service_port = service_key_v4.port;
                     let service_endpoint = format!("{}:{}", service_ip, service_port);
@@ -85,7 +98,7 @@ where
 
                     (service_endpoint, protocol, endpoints)
                 }
-                mesh_cni_ebpf_common::service::ServiceKey::V6(service_key_v6) => {
+                ServiceKey::V6(service_key_v6) => {
                     let service_ip = Ipv6Addr::from_bits(service_key_v6.ip);
                     let service_port = service_key_v6.port;
                     let service_endpoint = format!("{}:{}", service_ip, service_port);
@@ -106,14 +119,61 @@ where
                     (service_endpoint, protocol, endpoints)
                 }
             };
-            let s = ServiceWithEndpoints {
+            let service = ServiceWithEndpoints {
                 service_endpoint,
                 protocol,
                 endpoints,
             };
-            services.push(s);
+            services.push(service);
         }
         let response = Response::new(ListServicesReply { services });
+        Ok(response)
+    }
+
+    async fn list_node_ports(
+        &self,
+        _request: Request<ListNodePortsRequest>,
+    ) -> std::result::Result<Response<ListNodePortsReply>, Status> {
+        let nodeport_state = self
+            .state
+            .nodeport_state_from_cache()
+            .map_err(|e| Status::new(tonic::Code::Internal, e.to_string()))?;
+
+        let mut node_ports = vec![];
+        for (nodeport_key, service_key) in nodeport_state {
+            let protocol = KubeProtocol::try_from(nodeport_key.protocol as u32)
+                .map_err(|e| Status::new(tonic::Code::Internal, e))?
+                .to_string();
+            let service_endpoint = match service_key {
+                ServiceKey::V4(service_key_v4) => {
+                    format!(
+                        "{}:{}",
+                        Ipv4Addr::from_bits(service_key_v4.ip),
+                        service_key_v4.port
+                    )
+                }
+                ServiceKey::V6(service_key_v6) => {
+                    format!(
+                        "{}:{}",
+                        Ipv6Addr::from_bits(service_key_v6.ip),
+                        service_key_v6.port
+                    )
+                }
+            };
+
+            node_ports.push(NodePortService {
+                node_port: u32::from(nodeport_key.port),
+                protocol,
+                service_endpoint,
+            });
+        }
+
+        node_ports.sort_by(|a, b| {
+            a.node_port
+                .cmp(&b.node_port)
+                .then(a.protocol.cmp(&b.protocol))
+        });
+        let response = Response::new(ListNodePortsReply { node_ports });
         Ok(response)
     }
 }

--- a/mesh-cni/src/system/iface.rs
+++ b/mesh-cni/src/system/iface.rs
@@ -1,6 +1,7 @@
 use anyhow::bail;
 use rtnetlink::{Handle, LinkUnspec};
 use tokio_stream::StreamExt;
+use tracing::info;
 
 use crate::Result;
 
@@ -17,17 +18,24 @@ pub(crate) async fn ensure_mesh_veth() -> Result<()> {
         .match_name(MESH_HOST_INGRESS.to_string())
         .execute();
 
-    let iface_exists = links.try_next().await?.is_some();
+    info!("checking mesh_host interface presence");
+    let iface_exists = match links.try_next().await {
+        Ok(msg) if msg.is_some() => true,
+        Ok(_) => false,
+        Err(e) if is_enodev(&e) => false,
+        Err(e) => return Err(e.into()),
+    };
     if !iface_exists {
+        info!("creating mesh_host/mesh_pod veth");
         let add_result = handle
             .link()
             .add(rtnetlink::LinkVeth::new(MESH_HOST_INGRESS, MESH_POD_INGRESS).build())
             .execute()
             .await;
-        if let Err(err) = add_result
-            && !is_eexist(&err)
+        if let Err(e) = add_result
+            && !is_eexist(&e)
         {
-            return Err(err.into());
+            return Err(e.into());
         }
     }
 
@@ -53,6 +61,13 @@ async fn set_ifaces_up(handle: Handle, ifaces: &[&str]) -> Result<()> {
 fn is_eexist(err: &rtnetlink::Error) -> bool {
     match err {
         rtnetlink::Error::NetlinkError(msg) => msg.to_io().raw_os_error() == Some(libc::EEXIST),
+        _ => false,
+    }
+}
+
+fn is_enodev(err: &rtnetlink::Error) -> bool {
+    match err {
+        rtnetlink::Error::NetlinkError(msg) => msg.to_io().raw_os_error() == Some(libc::ENODEV),
         _ => false,
     }
 }


### PR DESCRIPTION
NodePort service reconciliation reconciles all Services generated a desired value set and the inserts/removes based on desired and current state. Added logic to nodeport to check for local IP association on desired IP as well and mesh_host/mesh_pod interface indexes.