### PR TITLE
mesh-cni: refactor service bpf related traits

### DIFF
--- a/mesh-cni-api/proto/service/v1/service.proto
+++ b/mesh-cni-api/proto/service/v1/service.proto
@@ -11,9 +11,7 @@ message ListServicesReply {
   repeated ServiceWithEndpoints services = 1;
 }
 
-message ListServicesRequest {
-  bool from_map = 1;
-}
+message ListServicesRequest {}
 
 message ServiceWithEndpoints {
   string service_endpoint = 1;

--- a/mesh-cni-cli/src/cli.rs
+++ b/mesh-cni-cli/src/cli.rs
@@ -46,9 +46,6 @@ pub enum IpCommands {
 pub enum ServiceCommands {
     /// List the Service and their associated IDs
     List {
-        #[arg(long)]
-        /// When set, pulls data from the bpf map instead of the cache
-        from_map: bool,
         #[arg(short = 'o', long, value_enum, default_value_t = OutputFormat::Table)]
         output: OutputFormat,
     },

--- a/mesh-cni-cli/src/service.rs
+++ b/mesh-cni-cli/src/service.rs
@@ -12,19 +12,15 @@ use crate::{
 pub(crate) async fn run(cmd: ServiceCommands) -> anyhow::Result<()> {
     let client = ServiceClient::connect(MESH_CNI_SOCKET).await?;
     match cmd {
-        ServiceCommands::List { from_map, output } => list(client, from_map, output).await?,
+        ServiceCommands::List { output } => list(client, output).await?,
         ServiceCommands::ListNodePorts { output } => list_nodeports(client, output).await?,
     }
     Ok(())
 }
 
-async fn list(
-    mut client: ServiceClient<Channel>,
-    from_map: bool,
-    output: OutputFormat,
-) -> anyhow::Result<()> {
+async fn list(mut client: ServiceClient<Channel>, output: OutputFormat) -> anyhow::Result<()> {
     let response = client
-        .list_services(Request::new(ListServicesRequest { from_map }))
+        .list_services(Request::new(ListServicesRequest::default()))
         .await?;
     let services = response.into_inner().services;
     output::print(services, output)
@@ -35,7 +31,7 @@ async fn list_nodeports(
     output: OutputFormat,
 ) -> anyhow::Result<()> {
     let response = client
-        .list_node_ports(Request::new(ListNodePortsRequest {}))
+        .list_node_ports(Request::new(ListNodePortsRequest::default()))
         .await?;
     let nodeports = response.into_inner().node_ports;
     output::print(nodeports, output)

--- a/mesh-cni-service-bpf-controller/src/context.rs
+++ b/mesh-cni-service-bpf-controller/src/context.rs
@@ -2,12 +2,7 @@ use k8s_openapi::api::{core::v1::Service, discovery::v1::EndpointSlice};
 use kube::runtime::reflector::Store;
 use mesh_cni_crds::v1alpha1::meshendpoint::MeshEndpoint;
 
-use crate::ServiceBpfState;
-
-pub struct Context<B>
-where
-    B: ServiceBpfState,
-{
+pub struct Context<B> {
     pub service_state: Store<Service>,
     pub endpoint_slice_state: Store<EndpointSlice>,
     pub mesh_endpoint_state: Store<MeshEndpoint>,

--- a/mesh-cni-service-bpf-controller/src/controller.rs
+++ b/mesh-cni-service-bpf-controller/src/controller.rs
@@ -17,14 +17,14 @@ use mesh_cni_ebpf_common::{
 use mesh_cni_meshendpoint_gen_controller::ANNOTATION_MESH_SERVICE;
 use tracing::{error, info};
 
-use crate::{Context, Error, Result, ServiceBpfState};
+use crate::{Context, Error, NodePortReader, NodePortWriter, Result, ServiceReader, ServiceWriter};
 
 const DEFAULT_REQUEUE_DURATION: Duration = Duration::from_secs(300);
 const ERROR_REQUEUE_DURATION: Duration = Duration::from_secs(5);
 const MISSING_MESH_ENDPOINT_REQUEUE_DURATION: Duration = Duration::from_secs(5);
 pub const SERVICE_OWNER_LABEL: &str = "kubernetes.io/service-name";
 
-pub async fn reconcile<B: ServiceBpfState>(
+pub async fn reconcile<B: ServiceWriter + ServiceReader>(
     service: Arc<Service>,
     ctx: Arc<Context<B>>,
 ) -> Result<Action> {
@@ -41,7 +41,7 @@ pub async fn reconcile<B: ServiceBpfState>(
     }
 }
 
-pub async fn reconcile_nodeports<B: ServiceBpfState>(
+pub async fn reconcile_nodeports<B: NodePortWriter + NodePortReader>(
     service: Arc<Service>,
     ctx: Arc<Context<B>>,
 ) -> Result<Action> {
@@ -55,7 +55,9 @@ pub async fn reconcile_nodeports<B: ServiceBpfState>(
     Ok(Action::await_change())
 }
 
-pub(crate) fn reconcile_all_nodeports<B: ServiceBpfState>(ctx: &Context<B>) -> Result<()> {
+pub(crate) fn reconcile_all_nodeports<B: NodePortWriter + NodePortReader>(
+    ctx: &Context<B>,
+) -> Result<()> {
     let desired_nodeports = desired_nodeport_mappings_for_services(&ctx.service_state.state());
     let current_nodeports = ctx.service_bpf_state.nodeport_state()?;
     let (keys_to_remove, keys_to_upsert) =
@@ -66,39 +68,39 @@ pub(crate) fn reconcile_all_nodeports<B: ServiceBpfState>(ctx: &Context<B>) -> R
     }
     for (nodeport_key, service_key) in keys_to_upsert {
         ctx.service_bpf_state
-            .update_nodeport(nodeport_key, service_key)?;
+            .upsert_nodeport(nodeport_key, service_key)?;
     }
 
     Ok(())
 }
 
-pub async fn reconcile_local_service<B: ServiceBpfState>(
+pub async fn reconcile_local_service<B: ServiceWriter + ServiceReader>(
     service: Arc<Service>,
     ctx: Arc<Context<B>>,
 ) -> Result<Action> {
     let desired = generate_desired_service_pairs(&service, &ctx);
-    let current = ctx.service_bpf_state.state()?;
+    let current = ctx.service_bpf_state.service_state()?;
     let is_deletion = service.meta().deletion_timestamp.is_some();
     let (keys_to_remove, entries_to_upsert) =
         diff_service_reconcile_actions(&service, &current, &desired, is_deletion);
 
     for key in keys_to_remove {
-        ctx.service_bpf_state.remove(&key)?;
+        ctx.service_bpf_state.remove_service(&key)?;
     }
 
     for (key, endpoints) in entries_to_upsert {
-        ctx.service_bpf_state.update(key, endpoints)?;
+        ctx.service_bpf_state.upsert_service(key, endpoints)?;
     }
 
     Ok(Action::requeue(DEFAULT_REQUEUE_DURATION))
 }
 
-pub async fn reconcile_multi_cluster_service<B: ServiceBpfState>(
+pub async fn reconcile_multi_cluster_service<B: ServiceWriter + ServiceReader>(
     service: Arc<Service>,
     ctx: Arc<Context<B>>,
 ) -> Result<Action> {
     let desired = generate_service_pairs_from_meps(&service, &ctx);
-    let current = ctx.service_bpf_state.state()?;
+    let current = ctx.service_bpf_state.service_state()?;
     let is_deletion = service.meta().deletion_timestamp.is_some();
     let mesh_endpoint_count = mesh_endpoint_count_for_service(&service, &ctx);
     let service_owned_key_count = service_owned_keys(&service, &current).len();
@@ -121,28 +123,24 @@ pub async fn reconcile_multi_cluster_service<B: ServiceBpfState>(
         diff_service_reconcile_actions(&service, &current, &desired, is_deletion);
 
     for key in keys_to_remove {
-        ctx.service_bpf_state.remove(&key)?;
+        ctx.service_bpf_state.remove_service(&key)?;
     }
 
     for (key, endpoints) in entries_to_upsert {
-        ctx.service_bpf_state.update(key, endpoints)?;
+        ctx.service_bpf_state.upsert_service(key, endpoints)?;
     }
 
     Ok(Action::requeue(DEFAULT_REQUEUE_DURATION))
 }
 
-pub fn error_policy<B: ServiceBpfState>(
-    service: Arc<Service>,
-    err: &Error,
-    _ctx: Arc<Context<B>>,
-) -> Action {
+pub fn error_policy<B>(service: Arc<Service>, err: &Error, _ctx: Arc<Context<B>>) -> Action {
     let ns = service.namespace().unwrap_or_default();
     let ns_name = format!("{}/{}", ns, service.name_any());
     error!(%err, "error reconciling {}", ns_name);
     Action::requeue(ERROR_REQUEUE_DURATION)
 }
 
-fn generate_desired_service_pairs<B: ServiceBpfState>(
+fn generate_desired_service_pairs<B>(
     service: &Service,
     ctx: &Context<B>,
 ) -> HashMap<ServiceKey, Vec<EndpointValue>> {
@@ -152,7 +150,7 @@ fn generate_desired_service_pairs<B: ServiceBpfState>(
     mesh_endpoint.generate_bpf_service_endpoints(&service_ips)
 }
 
-fn generate_service_pairs_from_meps<B: ServiceBpfState>(
+fn generate_service_pairs_from_meps<B>(
     service: &Service,
     ctx: &Context<B>,
 ) -> HashMap<ServiceKey, Vec<EndpointValue>> {
@@ -197,10 +195,7 @@ fn key_matches_service_ip(key: &ServiceKey, ips: &HashSet<IpAddr>) -> bool {
     ips.contains(&service_ip)
 }
 
-fn mesh_endpoint_count_for_service<B: ServiceBpfState>(
-    service: &Service,
-    ctx: &Context<B>,
-) -> usize {
+fn mesh_endpoint_count_for_service<B>(service: &Service, ctx: &Context<B>) -> usize {
     let Some(namespace) = service.namespace() else {
         return 0;
     };
@@ -261,7 +256,7 @@ fn is_meshed_service(service: &Service) -> bool {
     val.to_lowercase() == "true"
 }
 
-fn inner_reconcile_nodeports<B: ServiceBpfState>(
+fn inner_reconcile_nodeports<B: NodePortWriter + NodePortReader>(
     service: &Service,
     ctx: &Context<B>,
 ) -> Result<()> {
@@ -280,7 +275,7 @@ fn inner_reconcile_nodeports<B: ServiceBpfState>(
     }
     for (nodeport_key, service_key) in entries_to_upsert {
         ctx.service_bpf_state
-            .update_nodeport(nodeport_key, service_key)?;
+            .upsert_nodeport(nodeport_key, service_key)?;
     }
     Ok(())
 }

--- a/mesh-cni-service-bpf-controller/src/lib.rs
+++ b/mesh-cni-service-bpf-controller/src/lib.rs
@@ -11,11 +11,29 @@ pub use error::{Error, Result};
 use mesh_cni_ebpf_common::service::{EndpointValue, NodePortKey, ServiceKey};
 pub use runtime::start_bpf_service_controller;
 
-pub trait ServiceBpfState {
-    fn update(&self, key: ServiceKey, value: Vec<EndpointValue>) -> Result<()>;
-    fn remove(&self, key: &ServiceKey) -> Result<()>;
-    fn state(&self) -> Result<HashMap<ServiceKey, Vec<EndpointValue>>>;
-    fn update_nodeport(&self, key: NodePortKey, service_key: ServiceKey) -> Result<()>;
+pub trait ServiceWriter {
+    fn upsert_service(&self, key: ServiceKey, value: Vec<EndpointValue>) -> Result<()>;
+    fn remove_service(&self, key: &ServiceKey) -> Result<()>;
+}
+
+pub trait NodePortWriter {
+    fn upsert_nodeport(&self, key: NodePortKey, service_key: ServiceKey) -> Result<()>;
     fn remove_nodeport(&self, key: &NodePortKey) -> Result<()>;
+}
+
+pub trait ServiceReader {
+    fn service_state(&self) -> Result<HashMap<ServiceKey, Vec<EndpointValue>>>;
+}
+
+pub trait NodePortReader {
     fn nodeport_state(&self) -> Result<HashMap<NodePortKey, ServiceKey>>;
+}
+
+pub trait ServiceDataplane:
+    ServiceWriter + NodePortWriter + ServiceReader + NodePortReader
+{
+}
+impl<T> ServiceDataplane for T where
+    T: ServiceWriter + NodePortWriter + ServiceReader + NodePortReader
+{
 }

--- a/mesh-cni-service-bpf-controller/src/runtime.rs
+++ b/mesh-cni-service-bpf-controller/src/runtime.rs
@@ -12,7 +12,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::{error, info, warn};
 
 use crate::{
-    Context, Result, SERVICE_OWNER_LABEL, ServiceBpfState,
+    Context, Result, SERVICE_OWNER_LABEL, ServiceDataplane,
     controller::{error_policy, reconcile, reconcile_all_nodeports, reconcile_nodeports},
     utils::shutdown,
 };
@@ -23,7 +23,7 @@ pub async fn start_bpf_service_controller<B>(
     cancel: CancellationToken,
 ) -> Result<()>
 where
-    B: ServiceBpfState + Clone + Send + Sync + 'static,
+    B: ServiceDataplane + Clone + Send + Sync + 'static,
 {
     let service_api: Api<Service> = Api::all(kube_client.clone());
     let (service_state, service_subscriber) =

--- a/mesh-cni/src/agent.rs
+++ b/mesh-cni/src/agent.rs
@@ -65,13 +65,13 @@ pub async fn start(
     let nodeport_service_map = bpf::service::load_nodeport_service_map()?;
 
     info!("starting kube service service");
-    let service_endpoint_v4 = ServiceEndpoint::new(service_map_v4, endpoint_map_v4);
-    let service_endpoint_v6 = ServiceEndpoint::new(service_map_v6, endpoint_map_v6);
+    let service_endpoint_v4 = ServiceEndpoint::new(service_map_v4, endpoint_map_v4)?;
+    let service_endpoint_v6 = ServiceEndpoint::new(service_map_v6, endpoint_map_v6)?;
     let state = ServiceEndpointState::new(
         service_endpoint_v4,
         service_endpoint_v6,
         nodeport_service_map,
-    );
+    )?;
     bpf::service::run(
         kube_client.clone(),
         state.clone(),

--- a/mesh-cni/src/bpf/service/mod.rs
+++ b/mesh-cni/src/bpf/service/mod.rs
@@ -8,7 +8,7 @@ use mesh_cni_ebpf_common::service::{
     ServiceValue,
 };
 use mesh_cni_service_bpf_controller::start_bpf_service_controller;
-pub use state::{ServiceEndpoint, ServiceEndpointBpfMap, ServiceEndpointState};
+pub use state::{EndpointMapStore, ServiceEndpoint, ServiceEndpointState, ServiceMapStore};
 use tokio_util::sync::CancellationToken;
 use tracing::info;
 
@@ -33,11 +33,13 @@ pub async fn run<SE4, SE6, NP>(
     cancel: CancellationToken,
 ) -> Result<()>
 where
-    SE4: ServiceEndpointBpfMap<SKey = ServiceKeyV4, EValue = EndpointValueV4>
+    SE4: ServiceMapStore<SKey = ServiceKeyV4>
+        + EndpointMapStore<EValue = EndpointValueV4>
         + Send
         + Sync
         + 'static,
-    SE6: ServiceEndpointBpfMap<SKey = ServiceKeyV6, EValue = EndpointValueV6>
+    SE6: ServiceMapStore<SKey = ServiceKeyV6>
+        + EndpointMapStore<EValue = EndpointValueV6>
         + Send
         + Sync
         + 'static,

--- a/mesh-cni/src/bpf/service/state.rs
+++ b/mesh-cni/src/bpf/service/state.rs
@@ -13,7 +13,9 @@ use mesh_cni_ebpf_common::{
         ServiceKeyV4, ServiceKeyV6, ServiceValue,
     },
 };
-use mesh_cni_service_bpf_controller::{Error as BpfControllerError, ServiceBpfState};
+use mesh_cni_service_bpf_controller::{
+    Error as ControllerError, NodePortReader, NodePortWriter, ServiceReader, ServiceWriter,
+};
 use tracing::warn;
 
 use crate::{Result, bpf::BpfMap};
@@ -30,28 +32,118 @@ fn is_map_not_found_error(err: &anyhow::Error) -> bool {
         })
 }
 
-pub trait ServiceEndpointBpfMap {
-    type SKey: std::hash::Hash + std::cmp::Eq + Clone;
-    type EValue: Clone + std::cmp::PartialEq;
-    fn update(&mut self, key: Self::SKey, value: Vec<&Self::EValue>, id: Id) -> Result<Id>;
-    fn remove(&mut self, key: &Self::SKey) -> Result<()>;
-    fn get_from_cache(&self, key: &Self::SKey) -> Option<&ServiceValue>;
-    fn insert_new_service(
-        &mut self,
-        key: Self::SKey,
-        value: Vec<&Self::EValue>,
-        id: Id,
-    ) -> Result<Id>;
-    fn insert_endpoints(
-        &mut self,
-        service_value: &ServiceValue,
-        endpoints: Vec<&Self::EValue>,
-    ) -> Result<()>;
-    fn delete_endpoints(&mut self, service_value: &ServiceValue, range: Range<u16>) -> Result<()>;
-    fn get_service_cache(&self) -> &ahash::HashMap<Self::SKey, ServiceValue>;
-    fn get_service_map(&self) -> Result<ahash::HashMap<Self::SKey, ServiceValue>>;
-    fn get_endpoint_cache(&self) -> &ahash::HashMap<EndpointKey, Self::EValue>;
-    fn get_endpoint_map(&self) -> Result<ahash::HashMap<EndpointKey, Self::EValue>>;
+pub trait ServiceMapStore {
+    type SKey: std::hash::Hash + std::cmp::Eq + Copy;
+    fn update_service(&mut self, key: Self::SKey, value: ServiceValue) -> Result<()>;
+    fn delete_service(&mut self, key: &Self::SKey) -> Result<()>;
+    fn get_cached_service(&self, key: &Self::SKey) -> Option<&ServiceValue>;
+    fn insert_cached_service(&mut self, key: Self::SKey, value: ServiceValue);
+    fn remove_cached_service(&mut self, key: &Self::SKey);
+    fn service_cache(&self) -> &ahash::HashMap<Self::SKey, ServiceValue>;
+    fn service_map_state(&self) -> Result<ahash::HashMap<Self::SKey, ServiceValue>>;
+}
+
+pub trait EndpointMapStore {
+    type EValue: std::cmp::PartialEq + Copy;
+    fn update_endpoint(&mut self, key: EndpointKey, value: Self::EValue) -> Result<()>;
+    fn delete_endpoint(&mut self, key: &EndpointKey) -> Result<()>;
+    fn insert_cached_endpoint(&mut self, key: EndpointKey, value: Self::EValue);
+    fn remove_cached_endpoint(&mut self, key: &EndpointKey);
+    fn endpoint_cache(&self) -> &ahash::HashMap<EndpointKey, Self::EValue>;
+    fn endpoint_map_state(&self) -> Result<ahash::HashMap<EndpointKey, Self::EValue>>;
+}
+
+fn insert_endpoints<S>(
+    store: &mut S,
+    service_value: &ServiceValue,
+    endpoints: Vec<&S::EValue>,
+) -> Result<()>
+where
+    S: EndpointMapStore,
+{
+    for (position, ep) in endpoints.iter().enumerate() {
+        let position =
+            u16::try_from(position).map_err(|e| anyhow!("failed to convert position: {}", e))?;
+        let endpoint_key = EndpointKey::new(service_value.id, position);
+        store.update_endpoint(endpoint_key, **ep)?;
+        store.insert_cached_endpoint(endpoint_key, **ep);
+    }
+    Ok(())
+}
+
+fn delete_endpoints<S>(store: &mut S, service_value: &ServiceValue, range: Range<u16>) -> Result<()>
+where
+    S: EndpointMapStore,
+{
+    for idx in range {
+        let endpoint_key = EndpointKey::new(service_value.id, idx);
+        store.delete_endpoint(&endpoint_key)?;
+        store.remove_cached_endpoint(&endpoint_key);
+    }
+    Ok(())
+}
+
+fn update_service_with_endpoints<S>(
+    store: &mut S,
+    key: S::SKey,
+    endpoints: Vec<&S::EValue>,
+    mut id: Id,
+) -> Result<Id>
+where
+    S: ServiceMapStore + EndpointMapStore,
+{
+    let new_count = u16::try_from(endpoints.len()).map_err(|e| anyhow!(e.to_string()))?;
+
+    let Some(current_service_value) = store.get_cached_service(&key).copied() else {
+        let service_value = ServiceValue {
+            id,
+            count: new_count,
+        };
+        store.update_service(key, service_value)?;
+        store.insert_cached_service(key, service_value);
+        insert_endpoints(store, &service_value, endpoints)?;
+        id += 1;
+        return Ok(id);
+    };
+
+    let new_service_value = ServiceValue {
+        id: current_service_value.id,
+        count: new_count,
+    };
+
+    if new_count > current_service_value.count {
+        // Ensure new endpoint slots are populated before datapath can select them.
+        insert_endpoints(store, &new_service_value, endpoints)?;
+        store.update_service(key, new_service_value)?;
+    } else {
+        store.update_service(key, new_service_value)?;
+        insert_endpoints(store, &new_service_value, endpoints)?;
+
+        if current_service_value.count > new_count {
+            delete_endpoints(
+                store,
+                &new_service_value,
+                new_count..current_service_value.count,
+            )?;
+        }
+    }
+    store.insert_cached_service(key, new_service_value);
+
+    Ok(current_service_value.id)
+}
+
+fn remove_service_with_endpoints<S>(store: &mut S, key: &S::SKey) -> Result<()>
+where
+    S: ServiceMapStore + EndpointMapStore,
+{
+    let Some(service_value) = store.get_cached_service(key).copied() else {
+        return Ok(());
+    };
+
+    delete_endpoints(store, &service_value, 0..service_value.count)?;
+    store.delete_service(key)?;
+    store.remove_cached_service(key);
+    Ok(())
 }
 
 pub struct ServiceEndpoint<S, E, SK, EV>
@@ -74,144 +166,115 @@ where
     SK: std::hash::Hash + std::cmp::Eq + Clone + Copy,
     EV: Clone + std::cmp::PartialEq + Copy,
 {
-    // TODO: create cached maps from bpf maps?
-    pub fn new(service_map: S, endpoint_map: E) -> Self {
-        Self {
-            service_cache: ahash::HashMap::default(),
+    pub fn new(service_map: S, endpoint_map: E) -> Result<Self>
+    where
+        S: BpfMap<Key = SK, Value = ServiceValue, KeyOutput = SK>,
+        E: BpfMap<Key = EndpointKey, Value = EV, KeyOutput = EndpointKey>,
+    {
+        let service_cache = service_map.get_state()?;
+        let endpoint_cache = endpoint_map.get_state()?;
+        Ok(Self {
+            service_cache,
             service_map,
-            endpoint_cache: ahash::HashMap::default(),
+            endpoint_cache,
             endpoint_map,
-        }
+        })
+    }
+    pub fn update(&mut self, key: SK, value: Vec<&EV>, id: Id) -> Result<Id>
+    where
+        Self: ServiceMapStore<SKey = SK> + EndpointMapStore<EValue = EV>,
+    {
+        update_service_with_endpoints(self, key, value, id)
+    }
+
+    pub fn remove(&mut self, key: &SK) -> Result<()>
+    where
+        Self: ServiceMapStore<SKey = SK> + EndpointMapStore<EValue = EV>,
+    {
+        remove_service_with_endpoints(self, key)
+    }
+
+    pub fn get_from_cache(&self, key: &SK) -> Option<&ServiceValue>
+    where
+        Self: ServiceMapStore<SKey = SK>,
+    {
+        self.get_cached_service(key)
     }
 }
 
-impl<S, E, SK, EV> ServiceEndpointBpfMap for ServiceEndpoint<S, E, SK, EV>
+impl<S, E, SK, EV> ServiceMapStore for ServiceEndpoint<S, E, SK, EV>
 where
     S: BpfMap<Key = SK, Value = ServiceValue, KeyOutput = SK>,
     E: BpfMap<Key = EndpointKey, Value = EV, KeyOutput = EndpointKey>,
     SK: std::hash::Hash + std::cmp::Eq + Clone + Copy,
-    EV: Clone + std::cmp::PartialEq + Copy,
+    EV: std::cmp::PartialEq + Copy,
 {
     type SKey = SK;
-    type EValue = EV;
-    fn update(&mut self, key: Self::SKey, value: Vec<&Self::EValue>, id: Id) -> Result<Id> {
-        let new_count = u16::try_from(value.len()).map_err(|e| anyhow!(e.to_string()))?;
 
-        let Some(current_service_value) = self.service_cache.get(&key) else {
-            return self.insert_new_service(key, value, id);
-        };
-
-        let id = current_service_value.id;
-        let old_count = current_service_value.count;
-
-        let new_service_value = ServiceValue {
-            id,
-            count: new_count,
-        };
-
-        if new_count > old_count {
-            // Ensure new endpoint slots are populated before datapath can select them.
-            self.insert_endpoints(&new_service_value, value)?;
-            self.service_map.update(key, new_service_value)?;
-        } else {
-            self.service_map.update(key, new_service_value)?;
-            self.insert_endpoints(&new_service_value, value)?;
-
-            if old_count > new_count {
-                self.delete_endpoints(&new_service_value, new_count..old_count)?;
-            }
-        }
-        self.service_cache.insert(key, new_service_value);
-
-        Ok(id)
+    fn update_service(&mut self, key: Self::SKey, value: ServiceValue) -> Result<()> {
+        self.service_map.update(key, value)
     }
 
-    fn remove(&mut self, key: &Self::SKey) -> Result<()> {
-        let Some(service_value) = self.service_cache.get(key) else {
-            return Ok(());
-        };
-        let service_value = *service_value;
-
-        let range = 0..service_value.count;
-        self.delete_endpoints(&service_value, range)?;
-
-        self.service_map.delete(key)?;
-        self.service_cache.remove(key);
-        Ok(())
+    fn delete_service(&mut self, key: &Self::SKey) -> Result<()> {
+        self.service_map.delete(key)
     }
 
-    fn get_from_cache(&self, key: &Self::SKey) -> Option<&ServiceValue> {
+    fn get_cached_service(&self, key: &Self::SKey) -> Option<&ServiceValue> {
         self.service_cache.get(key)
     }
 
-    fn insert_new_service(
-        &mut self,
-        key: Self::SKey,
-        value: Vec<&Self::EValue>,
-        mut id: Id,
-    ) -> Result<Id> {
-        let count = u16::try_from(value.len()).map_err(|e| anyhow!(e.to_string()))?;
-        let service_value = ServiceValue { id, count };
-
-        self.service_map.update(key, service_value)?;
-        self.service_cache.insert(key, service_value);
-
-        for (position, endpoint) in value.iter().enumerate() {
-            let endpoint_key = EndpointKey::new(
-                id,
-                u16::try_from(position).map_err(|e| anyhow!(e.to_string()))?,
-            );
-
-            self.endpoint_map.update(endpoint_key, **endpoint)?;
-            self.endpoint_cache.insert(endpoint_key, **endpoint);
-        }
-        id += 1;
-        Ok(id)
+    fn insert_cached_service(&mut self, key: Self::SKey, value: ServiceValue) {
+        self.service_cache.insert(key, value);
     }
 
-    fn insert_endpoints(
-        &mut self,
-        service_value: &ServiceValue,
-        endpoints: Vec<&Self::EValue>,
-    ) -> Result<()> {
-        for (position, ep) in endpoints.iter().enumerate() {
-            let position = u16::try_from(position)
-                .map_err(|e| anyhow!("failed to convert position: {}", e))?;
-            let endpoint_key = EndpointKey::new(service_value.id, position);
-            self.endpoint_map.update(endpoint_key, **ep)?;
-            self.endpoint_cache.insert(endpoint_key, **ep);
-        }
-        Ok(())
+    fn remove_cached_service(&mut self, key: &Self::SKey) {
+        self.service_cache.remove(key);
     }
 
-    fn delete_endpoints(&mut self, service_value: &ServiceValue, range: Range<u16>) -> Result<()> {
-        for idx in range {
-            let endpoint_key = EndpointKey::new(service_value.id, idx);
-            self.endpoint_map.delete(&endpoint_key)?;
-            self.endpoint_cache.remove(&endpoint_key);
-        }
-        Ok(())
-    }
-
-    fn get_service_cache(&self) -> &ahash::HashMap<Self::SKey, ServiceValue> {
+    fn service_cache(&self) -> &ahash::HashMap<Self::SKey, ServiceValue> {
         &self.service_cache
     }
 
-    fn get_service_map(&self) -> Result<ahash::HashMap<Self::SKey, ServiceValue>> {
+    fn service_map_state(&self) -> Result<ahash::HashMap<Self::SKey, ServiceValue>> {
         let mut map = HashMap::default();
         let state = self.service_map.get_state()?;
-
         for (k, v) in state.iter() {
             map.insert(*k, *v);
         }
         Ok(map)
     }
+}
 
-    fn get_endpoint_cache(&self) -> &ahash::HashMap<EndpointKey, Self::EValue> {
+impl<S, E, SK, EV> EndpointMapStore for ServiceEndpoint<S, E, SK, EV>
+where
+    S: BpfMap<Key = SK, Value = ServiceValue, KeyOutput = SK>,
+    E: BpfMap<Key = EndpointKey, Value = EV, KeyOutput = EndpointKey>,
+    SK: std::hash::Hash + std::cmp::Eq + Clone + Copy,
+    EV: std::cmp::PartialEq + Copy,
+{
+    type EValue = EV;
+
+    fn update_endpoint(&mut self, key: EndpointKey, value: Self::EValue) -> Result<()> {
+        self.endpoint_map.update(key, value)
+    }
+
+    fn delete_endpoint(&mut self, key: &EndpointKey) -> Result<()> {
+        self.endpoint_map.delete(key)
+    }
+
+    fn insert_cached_endpoint(&mut self, key: EndpointKey, value: Self::EValue) {
+        self.endpoint_cache.insert(key, value);
+    }
+
+    fn remove_cached_endpoint(&mut self, key: &EndpointKey) {
+        self.endpoint_cache.remove(key);
+    }
+
+    fn endpoint_cache(&self) -> &ahash::HashMap<EndpointKey, Self::EValue> {
         &self.endpoint_cache
     }
 
-    fn get_endpoint_map(&self) -> Result<ahash::HashMap<EndpointKey, Self::EValue>> {
+    fn endpoint_map_state(&self) -> Result<ahash::HashMap<EndpointKey, Self::EValue>> {
         let mut map = HashMap::default();
         let state = self.endpoint_map.get_state()?;
         for (k, v) in state.iter() {
@@ -223,8 +286,8 @@ where
 
 struct Shared<SE4, SE6, NP>
 where
-    SE4: ServiceEndpointBpfMap,
-    SE6: ServiceEndpointBpfMap,
+    SE4: ServiceMapStore + EndpointMapStore,
+    SE6: ServiceMapStore + EndpointMapStore,
     NP: BpfMap<Key = NodePortKey, Value = ServiceKeyV4, KeyOutput = NodePortKey>,
 {
     state: Mutex<State<SE4, SE6, NP>>,
@@ -232,8 +295,8 @@ where
 
 struct State<SE4, SE6, NP>
 where
-    SE4: ServiceEndpointBpfMap,
-    SE6: ServiceEndpointBpfMap,
+    SE4: ServiceMapStore + EndpointMapStore,
+    SE6: ServiceMapStore + EndpointMapStore,
     NP: BpfMap<Key = NodePortKey, Value = ServiceKeyV4, KeyOutput = NodePortKey>,
 {
     service_endpoint_v4: SE4,
@@ -245,8 +308,8 @@ where
 
 pub struct ServiceEndpointState<SE4, SE6, NP>
 where
-    SE4: ServiceEndpointBpfMap<SKey = ServiceKeyV4, EValue = EndpointValueV4>,
-    SE6: ServiceEndpointBpfMap<SKey = ServiceKeyV6, EValue = EndpointValueV6>,
+    SE4: ServiceMapStore<SKey = ServiceKeyV4> + EndpointMapStore<EValue = EndpointValueV4>,
+    SE6: ServiceMapStore<SKey = ServiceKeyV6> + EndpointMapStore<EValue = EndpointValueV6>,
     NP: BpfMap<Key = NodePortKey, Value = ServiceKeyV4, KeyOutput = NodePortKey>,
 {
     shared: Arc<Shared<SE4, SE6, NP>>,
@@ -254,8 +317,8 @@ where
 
 impl<SE4, SE6, NP> Clone for ServiceEndpointState<SE4, SE6, NP>
 where
-    SE4: ServiceEndpointBpfMap<SKey = ServiceKeyV4, EValue = EndpointValueV4>,
-    SE6: ServiceEndpointBpfMap<SKey = ServiceKeyV6, EValue = EndpointValueV6>,
+    SE4: ServiceMapStore<SKey = ServiceKeyV4> + EndpointMapStore<EValue = EndpointValueV4>,
+    SE6: ServiceMapStore<SKey = ServiceKeyV6> + EndpointMapStore<EValue = EndpointValueV6>,
     NP: BpfMap<Key = NodePortKey, Value = ServiceKeyV4, KeyOutput = NodePortKey>,
 {
     fn clone(&self) -> Self {
@@ -267,21 +330,39 @@ where
 
 impl<SE4, SE6, NP> ServiceEndpointState<SE4, SE6, NP>
 where
-    SE4: ServiceEndpointBpfMap<SKey = ServiceKeyV4, EValue = EndpointValueV4>,
-    SE6: ServiceEndpointBpfMap<SKey = ServiceKeyV6, EValue = EndpointValueV6>,
+    SE4: ServiceMapStore<SKey = ServiceKeyV4> + EndpointMapStore<EValue = EndpointValueV4>,
+    SE6: ServiceMapStore<SKey = ServiceKeyV6> + EndpointMapStore<EValue = EndpointValueV6>,
     NP: BpfMap<Key = NodePortKey, Value = ServiceKeyV4, KeyOutput = NodePortKey>,
 {
     pub(crate) fn new(
         service_endpoint_v4: SE4,
         service_endpoint_v6: SE6,
         nodeport_map: NP,
-    ) -> Self {
+    ) -> Result<Self> {
+        let nodeport_cache = nodeport_map.get_state()?;
+        let next_id = {
+            let max_id_v4 = service_endpoint_v4
+                .service_cache()
+                .values()
+                .map(|service_value| service_value.id)
+                .max();
+            let max_id_v6 = service_endpoint_v6
+                .service_cache()
+                .values()
+                .map(|service_value| service_value.id)
+                .max();
+            let max_existing = max_id_v4.into_iter().chain(max_id_v6).max();
+            std::cmp::max(
+                128,
+                max_existing.map(|id| id.saturating_add(1)).unwrap_or(128),
+            )
+        };
         let state = State {
             service_endpoint_v4,
             service_endpoint_v6,
-            nodeport_cache: ahash::HashMap::default(),
+            nodeport_cache,
             nodeport_map,
-            id: 128,
+            id: next_id,
         };
 
         let shared = Shared {
@@ -289,7 +370,7 @@ where
         };
         let shared = Arc::new(shared);
 
-        Self { shared }
+        Ok(Self { shared })
     }
 
     pub(crate) fn update(&self, key: ServiceKey, value: Vec<EndpointValue>) -> Result<()> {
@@ -307,9 +388,12 @@ where
                         }
                     })
                     .collect();
-                state
-                    .service_endpoint_v4
-                    .update(service_key_v4, endpoints, current_id)?
+                update_service_with_endpoints(
+                    &mut state.service_endpoint_v4,
+                    service_key_v4,
+                    endpoints,
+                    current_id,
+                )?
             }
             ServiceKey::V6(service_key_v6) => {
                 let endpoints = value
@@ -322,9 +406,12 @@ where
                         }
                     })
                     .collect();
-                state
-                    .service_endpoint_v6
-                    .update(service_key_v6, endpoints, current_id)?
+                update_service_with_endpoints(
+                    &mut state.service_endpoint_v6,
+                    service_key_v6,
+                    endpoints,
+                    current_id,
+                )?
             }
         };
         if new_id > current_id {
@@ -337,10 +424,10 @@ where
         let mut state = self.shared.state.lock().unwrap();
         match key {
             ServiceKey::V4(service_key_v4) => {
-                state.service_endpoint_v4.remove(service_key_v4)?;
+                remove_service_with_endpoints(&mut state.service_endpoint_v4, service_key_v4)?;
             }
             ServiceKey::V6(service_key_v6) => {
-                state.service_endpoint_v6.remove(service_key_v6)?;
+                remove_service_with_endpoints(&mut state.service_endpoint_v6, service_key_v6)?;
             }
         }
         Ok(())
@@ -374,17 +461,6 @@ where
         }
     }
 
-    pub(crate) fn nodeport_state_from_map(
-        &self,
-    ) -> Result<ahash::HashMap<NodePortKey, ServiceKey>> {
-        let state = self.shared.state.lock().unwrap();
-        let map = state.nodeport_map.get_state()?;
-        Ok(map
-            .into_iter()
-            .map(|(nodeport_key, service_key)| (nodeport_key, ServiceKey::V4(service_key)))
-            .collect())
-    }
-
     pub(crate) fn nodeport_state_from_cache(
         &self,
     ) -> Result<ahash::HashMap<NodePortKey, ServiceKey>> {
@@ -401,8 +477,8 @@ where
     ) -> Result<ahash::HashMap<ServiceKey, Vec<EndpointValue>>> {
         let state = self.shared.state.lock().unwrap();
         let mut map = ahash::HashMap::new();
-        let cached_service_v4 = state.service_endpoint_v4.get_service_cache();
-        let cached_endpoints_v4 = state.service_endpoint_v4.get_endpoint_cache();
+        let cached_service_v4 = state.service_endpoint_v4.service_cache();
+        let cached_endpoints_v4 = state.service_endpoint_v4.endpoint_cache();
         for (k, v) in cached_service_v4 {
             let mut endpoints = vec![];
             let count = v.count;
@@ -416,8 +492,8 @@ where
             }
             map.insert(ServiceKey::V4(k.to_owned()), endpoints);
         }
-        let cached_service_v6 = state.service_endpoint_v6.get_service_cache();
-        let cached_endpoints_v6 = state.service_endpoint_v6.get_endpoint_cache();
+        let cached_service_v6 = state.service_endpoint_v6.service_cache();
+        let cached_endpoints_v6 = state.service_endpoint_v6.endpoint_cache();
         for (k, v) in cached_service_v6 {
             let mut endpoints = vec![];
             let count = v.count;
@@ -433,94 +509,75 @@ where
         }
         Ok(map)
     }
-
-    // TODO: refactor with state from cache into one func
-    pub(crate) fn state_from_map(&self) -> Result<ahash::HashMap<ServiceKey, Vec<EndpointValue>>> {
-        let mut map = ahash::HashMap::default();
-        let guard = self.shared.state.lock().unwrap();
-        let service_map_v4 = guard.service_endpoint_v4.get_service_map()?;
-        let endpoint_map_v4 = guard.service_endpoint_v4.get_endpoint_map()?;
-
-        for (k, v) in service_map_v4 {
-            let mut endpoints = vec![];
-            let count = v.count;
-            for idx in 0..count {
-                let Some(endpoint_value) = endpoint_map_v4.get(&EndpointKey::new(v.id, idx)) else {
-                    warn!("did not find endpoints with id {} and idx {}", v.id, idx);
-                    continue;
-                };
-                endpoints.push(EndpointValue::V4(endpoint_value.to_owned()));
-            }
-            map.insert(ServiceKey::V4(k.to_owned()), endpoints);
-        }
-
-        let service_map_v6 = guard.service_endpoint_v6.get_service_map()?;
-        let endpoint_map_v6 = guard.service_endpoint_v6.get_endpoint_map()?;
-
-        for (k, v) in service_map_v6 {
-            let mut endpoints = vec![];
-            let count = v.count;
-            for idx in 0..count {
-                let Some(endpoint_value) = endpoint_map_v6.get(&EndpointKey::new(v.id, idx)) else {
-                    warn!("did not find endpoints with id {} and idx {}", v.id, idx);
-                    continue;
-                };
-                endpoints.push(EndpointValue::V6(endpoint_value.to_owned()));
-            }
-            map.insert(ServiceKey::V6(k.to_owned()), endpoints);
-        }
-
-        Ok(map)
-    }
 }
 
-impl<SE4, SE6, NP> ServiceBpfState for ServiceEndpointState<SE4, SE6, NP>
+impl<SE4, SE6, NP> ServiceWriter for ServiceEndpointState<SE4, SE6, NP>
 where
-    SE4: ServiceEndpointBpfMap<SKey = ServiceKeyV4, EValue = EndpointValueV4>,
-    SE6: ServiceEndpointBpfMap<SKey = ServiceKeyV6, EValue = EndpointValueV6>,
+    SE4: ServiceMapStore<SKey = ServiceKeyV4> + EndpointMapStore<EValue = EndpointValueV4>,
+    SE6: ServiceMapStore<SKey = ServiceKeyV6> + EndpointMapStore<EValue = EndpointValueV6>,
     NP: BpfMap<Key = NodePortKey, Value = ServiceKeyV4, KeyOutput = NodePortKey>,
 {
-    fn update(
+    fn upsert_service(
         &self,
         key: ServiceKey,
         value: Vec<EndpointValue>,
-    ) -> std::result::Result<(), BpfControllerError> {
+    ) -> std::result::Result<(), ControllerError> {
         ServiceEndpointState::update(self, key, value)
-            .map_err(|e| BpfControllerError::BpfState(e.to_string()))
+            .map_err(|e| ControllerError::BpfState(e.to_string()))
     }
 
-    fn remove(&self, key: &ServiceKey) -> std::result::Result<(), BpfControllerError> {
+    fn remove_service(&self, key: &ServiceKey) -> std::result::Result<(), ControllerError> {
         ServiceEndpointState::remove(self, key)
-            .map_err(|e| BpfControllerError::BpfState(e.to_string()))
+            .map_err(|e| ControllerError::BpfState(e.to_string()))
     }
+}
 
-    fn state(
-        &self,
-    ) -> std::result::Result<ahash::HashMap<ServiceKey, Vec<EndpointValue>>, BpfControllerError>
-    {
-        ServiceEndpointState::state_from_map(self)
-            .map_err(|e| BpfControllerError::BpfState(e.to_string()))
-    }
-
-    fn update_nodeport(
+impl<SE4, SE6, NP> NodePortWriter for ServiceEndpointState<SE4, SE6, NP>
+where
+    SE4: ServiceMapStore<SKey = ServiceKeyV4> + EndpointMapStore<EValue = EndpointValueV4>,
+    SE6: ServiceMapStore<SKey = ServiceKeyV6> + EndpointMapStore<EValue = EndpointValueV6>,
+    NP: BpfMap<Key = NodePortKey, Value = ServiceKeyV4, KeyOutput = NodePortKey>,
+{
+    fn upsert_nodeport(
         &self,
         key: NodePortKey,
         service_key: ServiceKey,
-    ) -> std::result::Result<(), BpfControllerError> {
+    ) -> std::result::Result<(), ControllerError> {
         ServiceEndpointState::update_nodeport(self, key, service_key)
-            .map_err(|e| BpfControllerError::BpfState(e.to_string()))
+            .map_err(|e| ControllerError::BpfState(e.to_string()))
     }
 
-    fn remove_nodeport(&self, key: &NodePortKey) -> std::result::Result<(), BpfControllerError> {
+    fn remove_nodeport(&self, key: &NodePortKey) -> std::result::Result<(), ControllerError> {
         ServiceEndpointState::remove_nodeport(self, key)
-            .map_err(|e| BpfControllerError::BpfState(e.to_string()))
+            .map_err(|e| ControllerError::BpfState(e.to_string()))
     }
+}
 
+impl<SE4, SE6, NP> ServiceReader for ServiceEndpointState<SE4, SE6, NP>
+where
+    SE4: ServiceMapStore<SKey = ServiceKeyV4> + EndpointMapStore<EValue = EndpointValueV4>,
+    SE6: ServiceMapStore<SKey = ServiceKeyV6> + EndpointMapStore<EValue = EndpointValueV6>,
+    NP: BpfMap<Key = NodePortKey, Value = ServiceKeyV4, KeyOutput = NodePortKey>,
+{
+    fn service_state(
+        &self,
+    ) -> std::result::Result<ahash::HashMap<ServiceKey, Vec<EndpointValue>>, ControllerError> {
+        ServiceEndpointState::state_from_cache(self)
+            .map_err(|e| ControllerError::BpfState(e.to_string()))
+    }
+}
+
+impl<SE4, SE6, NP> NodePortReader for ServiceEndpointState<SE4, SE6, NP>
+where
+    SE4: ServiceMapStore<SKey = ServiceKeyV4> + EndpointMapStore<EValue = EndpointValueV4>,
+    SE6: ServiceMapStore<SKey = ServiceKeyV6> + EndpointMapStore<EValue = EndpointValueV6>,
+    NP: BpfMap<Key = NodePortKey, Value = ServiceKeyV4, KeyOutput = NodePortKey>,
+{
     fn nodeport_state(
         &self,
-    ) -> std::result::Result<ahash::HashMap<NodePortKey, ServiceKey>, BpfControllerError> {
-        ServiceEndpointState::nodeport_state_from_map(self)
-            .map_err(|e| BpfControllerError::BpfState(e.to_string()))
+    ) -> std::result::Result<ahash::HashMap<NodePortKey, ServiceKey>, ControllerError> {
+        ServiceEndpointState::nodeport_state_from_cache(self)
+            .map_err(|e| ControllerError::BpfState(e.to_string()))
     }
 }
 
@@ -541,7 +598,7 @@ mod test {
     > {
         let service_map: HashMap<ServiceKeyV4, ServiceValue> = HashMap::default();
         let endpoint_map: HashMap<EndpointKey, EndpointValueV4> = HashMap::default();
-        ServiceEndpoint::new(service_map, endpoint_map)
+        ServiceEndpoint::new(service_map, endpoint_map).unwrap()
     }
 
     fn new_service_endpoint_state() -> ServiceEndpointState<
@@ -559,10 +616,10 @@ mod test {
         >,
         HashMap<NodePortKey, ServiceKeyV4>,
     > {
-        let service_v4 = ServiceEndpoint::new(HashMap::default(), HashMap::default());
-        let service_v6 = ServiceEndpoint::new(HashMap::default(), HashMap::default());
+        let service_v4 = ServiceEndpoint::new(HashMap::default(), HashMap::default()).unwrap();
+        let service_v6 = ServiceEndpoint::new(HashMap::default(), HashMap::default()).unwrap();
         let nodeport = HashMap::default();
-        ServiceEndpointState::new(service_v4, service_v6, nodeport)
+        ServiceEndpointState::new(service_v4, service_v6, nodeport).unwrap()
     }
 
     #[test]
@@ -663,7 +720,7 @@ mod test {
                 KubeProtocol::Tcp as u8,
             ),
         )?;
-        let nodeport_state = state.nodeport_state_from_map()?;
+        let nodeport_state = state.nodeport_state_from_cache()?;
 
         assert!(nodeport_state.contains_key(&nodeport_key));
         Ok(())

--- a/mesh-cni/src/http/grpc/service.rs
+++ b/mesh-cni/src/http/grpc/service.rs
@@ -17,15 +17,21 @@ use tracing::info;
 
 use crate::bpf::{
     BpfMap,
-    service::{ServiceEndpointBpfMap, ServiceEndpointState},
+    service::{EndpointMapStore, ServiceEndpointState, ServiceMapStore},
 };
 
 pub fn server<SE4, SE6, NP>(
     state: ServiceEndpointState<SE4, SE6, NP>,
 ) -> ServiceServer<Server<SE4, SE6, NP>>
 where
-    SE4: ServiceEndpointBpfMap<SKey = ServiceKeyV4, EValue = EndpointValueV4> + Send + 'static,
-    SE6: ServiceEndpointBpfMap<SKey = ServiceKeyV6, EValue = EndpointValueV6> + Send + 'static,
+    SE4: ServiceMapStore<SKey = ServiceKeyV4>
+        + EndpointMapStore<EValue = EndpointValueV4>
+        + Send
+        + 'static,
+    SE6: ServiceMapStore<SKey = ServiceKeyV6>
+        + EndpointMapStore<EValue = EndpointValueV6>
+        + Send
+        + 'static,
     NP: BpfMap<Key = NodePortKey, Value = ServiceKeyV4, KeyOutput = NodePortKey> + Send + 'static,
 {
     info!("creating new service state");
@@ -36,8 +42,8 @@ where
 #[derive(Clone)]
 pub struct Server<SE4, SE6, NP>
 where
-    SE4: ServiceEndpointBpfMap<SKey = ServiceKeyV4, EValue = EndpointValueV4>,
-    SE6: ServiceEndpointBpfMap<SKey = ServiceKeyV6, EValue = EndpointValueV6>,
+    SE4: ServiceMapStore<SKey = ServiceKeyV4> + EndpointMapStore<EValue = EndpointValueV4>,
+    SE6: ServiceMapStore<SKey = ServiceKeyV6> + EndpointMapStore<EValue = EndpointValueV6>,
     NP: BpfMap<Key = NodePortKey, Value = ServiceKeyV4, KeyOutput = NodePortKey>,
 {
     state: ServiceEndpointState<SE4, SE6, NP>,
@@ -45,8 +51,8 @@ where
 
 impl<SE4, SE6, NP> Server<SE4, SE6, NP>
 where
-    SE4: ServiceEndpointBpfMap<SKey = ServiceKeyV4, EValue = EndpointValueV4>,
-    SE6: ServiceEndpointBpfMap<SKey = ServiceKeyV6, EValue = EndpointValueV6>,
+    SE4: ServiceMapStore<SKey = ServiceKeyV4> + EndpointMapStore<EValue = EndpointValueV4>,
+    SE6: ServiceMapStore<SKey = ServiceKeyV6> + EndpointMapStore<EValue = EndpointValueV6>,
     NP: BpfMap<Key = NodePortKey, Value = ServiceKeyV4, KeyOutput = NodePortKey>,
 {
     pub fn new(state: ServiceEndpointState<SE4, SE6, NP>) -> Self {
@@ -57,24 +63,24 @@ where
 #[tonic::async_trait]
 impl<SE4, SE6, NP> ServiceApi for Server<SE4, SE6, NP>
 where
-    SE4: ServiceEndpointBpfMap<SKey = ServiceKeyV4, EValue = EndpointValueV4> + Send + 'static,
-    SE6: ServiceEndpointBpfMap<SKey = ServiceKeyV6, EValue = EndpointValueV6> + Send + 'static,
+    SE4: ServiceMapStore<SKey = ServiceKeyV4>
+        + EndpointMapStore<EValue = EndpointValueV4>
+        + Send
+        + 'static,
+    SE6: ServiceMapStore<SKey = ServiceKeyV6>
+        + EndpointMapStore<EValue = EndpointValueV6>
+        + Send
+        + 'static,
     NP: BpfMap<Key = NodePortKey, Value = ServiceKeyV4, KeyOutput = NodePortKey> + Send + 'static,
 {
     async fn list_services(
         &self,
-        request: Request<ListServicesRequest>,
+        _request: Request<ListServicesRequest>,
     ) -> std::result::Result<Response<ListServicesReply>, Status> {
-        let request = request.into_inner();
-        let state = if request.from_map {
-            self.state
-                .state_from_map()
-                .map_err(|e| Status::new(tonic::Code::Internal, e.to_string()))?
-        } else {
-            self.state
-                .state_from_cache()
-                .map_err(|e| Status::new(tonic::Code::Internal, e.to_string()))?
-        };
+        let state = self
+            .state
+            .state_from_cache()
+            .map_err(|e| Status::new(tonic::Code::Internal, e.to_string()))?;
         let mut services = vec![];
         for (k, v) in state.iter() {
             let (service_endpoint, protocol, endpoints) = match k {


### PR DESCRIPTION
Narrow down traits to be easier to read and reason about. Fix cache state hydration ensuring cache and bpf maps are always in-sync.