### PR TITLE
mesh-cni: hydrate IP cache from map

### DIFF
--- a/mesh-cni/src/agent.rs
+++ b/mesh-cni/src/agent.rs
@@ -47,7 +47,7 @@ pub async fn start(
 
     info!("loading ip maps");
     let (ipv4_map, ipv6_map) = bpf::ip::load_maps()?;
-    let state = IpNetworkState::new(ipv4_map, ipv6_map);
+    let state = IpNetworkState::try_new(ipv4_map, ipv6_map)?;
 
     info!("starting ip service");
     bpf::ip::run(
@@ -65,8 +65,8 @@ pub async fn start(
     let nodeport_service_map = bpf::service::load_nodeport_service_map()?;
 
     info!("starting kube service service");
-    let service_endpoint_v4 = ServiceEndpoint::new(service_map_v4, endpoint_map_v4)?;
-    let service_endpoint_v6 = ServiceEndpoint::new(service_map_v6, endpoint_map_v6)?;
+    let service_endpoint_v4 = ServiceEndpoint::try_new(service_map_v4, endpoint_map_v4)?;
+    let service_endpoint_v6 = ServiceEndpoint::try_new(service_map_v6, endpoint_map_v6)?;
     let state = ServiceEndpointState::new(
         service_endpoint_v4,
         service_endpoint_v6,

--- a/mesh-cni/src/bpf/ip/mod.rs
+++ b/mesh-cni/src/bpf/ip/mod.rs
@@ -25,8 +25,14 @@ pub async fn run<IP4, IP6>(
     cancel: CancellationToken,
 ) -> Result<()>
 where
-    IP4: BpfMap<Key = LpmKey<u32>, Value = IdentityId> + Send + Sync + 'static,
-    IP6: BpfMap<Key = LpmKey<u128>, Value = IdentityId> + Send + Sync + 'static,
+    IP4: BpfMap<Key = LpmKey<u32>, Value = IdentityId, KeyOutput = IpNetwork>
+        + Send
+        + Sync
+        + 'static,
+    IP6: BpfMap<Key = LpmKey<u128>, Value = IdentityId, KeyOutput = IpNetwork>
+        + Send
+        + Sync
+        + 'static,
 {
     bootstrap_default_identities(&ipstate)?;
 
@@ -38,8 +44,14 @@ where
 
 fn bootstrap_default_identities<IP4, IP6>(ipstate: &IpNetworkState<IP4, IP6>) -> Result<()>
 where
-    IP4: BpfMap<Key = LpmKey<u32>, Value = IdentityId> + Send + Sync + 'static,
-    IP6: BpfMap<Key = LpmKey<u128>, Value = IdentityId> + Send + Sync + 'static,
+    IP4: BpfMap<Key = LpmKey<u32>, Value = IdentityId, KeyOutput = IpNetwork>
+        + Send
+        + Sync
+        + 'static,
+    IP6: BpfMap<Key = LpmKey<u128>, Value = IdentityId, KeyOutput = IpNetwork>
+        + Send
+        + Sync
+        + 'static,
 {
     let defaults = [
         IpNetwork::V4(Ipv4Network::new(Ipv4Addr::new(127, 0, 0, 0), 8)?),

--- a/mesh-cni/src/bpf/ip/state.rs
+++ b/mesh-cni/src/bpf/ip/state.rs
@@ -12,8 +12,8 @@ use crate::{
 
 struct Shared<IP4, IP6>
 where
-    IP4: BpfMap,
-    IP6: BpfMap,
+    IP4: BpfMap<Key = LpmKey<u32>, Value = IdentityId, KeyOutput = IpNetwork>,
+    IP6: BpfMap<Key = LpmKey<u128>, Value = IdentityId, KeyOutput = IpNetwork>,
 {
     shared: Mutex<State<IP4, IP6>>,
 }
@@ -23,8 +23,8 @@ where
 // the map permanently
 struct State<IP4, IP6>
 where
-    IP4: BpfMap,
-    IP6: BpfMap,
+    IP4: BpfMap<Key = LpmKey<u32>, Value = IdentityId, KeyOutput = IpNetwork>,
+    IP6: BpfMap<Key = LpmKey<u128>, Value = IdentityId, KeyOutput = IpNetwork>,
 {
     ipv4_state: IpBpfStateV4<IP4>,
     ipv6_state: IpBpfStateV6<IP6>,
@@ -32,8 +32,8 @@ where
 
 impl<IP4, IP6> Clone for IpNetworkState<IP4, IP6>
 where
-    IP4: BpfMap,
-    IP6: BpfMap,
+    IP4: BpfMap<Key = LpmKey<u32>, Value = IdentityId, KeyOutput = IpNetwork>,
+    IP6: BpfMap<Key = LpmKey<u128>, Value = IdentityId, KeyOutput = IpNetwork>,
 {
     fn clone(&self) -> Self {
         let new = Arc::clone(&self.state);
@@ -43,20 +43,20 @@ where
 
 pub struct IpNetworkState<IP4, IP6>
 where
-    IP4: BpfMap,
-    IP6: BpfMap,
+    IP4: BpfMap<Key = LpmKey<u32>, Value = IdentityId, KeyOutput = IpNetwork>,
+    IP6: BpfMap<Key = LpmKey<u128>, Value = IdentityId, KeyOutput = IpNetwork>,
 {
     state: Arc<Shared<IP4, IP6>>,
 }
 
 impl<IP4, IP6> IpNetworkState<IP4, IP6>
 where
-    IP4: BpfMap<Key = LpmKey<u32>, Value = IdentityId>,
-    IP6: BpfMap<Key = LpmKey<u128>, Value = IdentityId>,
+    IP4: BpfMap<Key = LpmKey<u32>, Value = IdentityId, KeyOutput = IpNetwork>,
+    IP6: BpfMap<Key = LpmKey<u128>, Value = IdentityId, KeyOutput = IpNetwork>,
 {
-    pub fn new(ipv4_map: IP4, ipv6_map: IP6) -> Self {
-        let ipv4_state = IpBpfStateV4::new(ipv4_map);
-        let ipv6_state = IpBpfStateV6::new(ipv6_map);
+    pub fn try_new(ipv4_map: IP4, ipv6_map: IP6) -> Result<Self> {
+        let ipv4_state = IpBpfStateV4::try_new(ipv4_map)?;
+        let ipv6_state = IpBpfStateV6::try_new(ipv6_map)?;
         let state = State {
             ipv4_state,
             ipv6_state,
@@ -64,9 +64,9 @@ where
         let shared = Shared {
             shared: Mutex::new(state),
         };
-        Self {
+        Ok(Self {
             state: Arc::new(shared),
-        }
+        })
     }
     // TODO: check if this can error with notifications
     // LpmTrie expects big endian order for comparisons
@@ -121,8 +121,8 @@ where
 
 impl<IP4, IP6> IdentityBpfState for IpNetworkState<IP4, IP6>
 where
-    IP4: BpfMap<Key = LpmKey<u32>, Value = IdentityId>,
-    IP6: BpfMap<Key = LpmKey<u128>, Value = IdentityId>,
+    IP4: BpfMap<Key = LpmKey<u32>, Value = IdentityId, KeyOutput = IpNetwork>,
+    IP6: BpfMap<Key = LpmKey<u128>, Value = IdentityId, KeyOutput = IpNetwork>,
 {
     fn update(
         &self,
@@ -145,7 +145,7 @@ where
 
 pub struct IpBpfStateV4<M>
 where
-    M: BpfMap,
+    M: BpfMap<Key = LpmKey<u32>, Value = IdentityId, KeyOutput = IpNetwork>,
 {
     cache: ahash::HashMap<IpNetwork, IdentityId>,
     bpf_map: M,
@@ -153,11 +153,11 @@ where
 
 impl<M> IpBpfStateV4<M>
 where
-    M: BpfMap<Key = LpmKey<u32>, Value = IdentityId>,
+    M: BpfMap<Key = LpmKey<u32>, Value = IdentityId, KeyOutput = IpNetwork>,
 {
-    pub fn new(bpf_map: M) -> Self {
-        let cache = ahash::HashMap::default();
-        Self { cache, bpf_map }
+    pub fn try_new(bpf_map: M) -> Result<Self> {
+        let cache = bpf_map.get_state()?;
+        Ok(Self { cache, bpf_map })
     }
 
     pub fn update(&mut self, key: M::Key, value: M::Value) -> Result<()> {
@@ -190,7 +190,7 @@ where
 
 pub struct IpBpfStateV6<M>
 where
-    M: BpfMap,
+    M: BpfMap<Key = LpmKey<u128>, Value = IdentityId, KeyOutput = IpNetwork>,
 {
     cache: ahash::HashMap<IpNetwork, IdentityId>,
     bpf_map: M,
@@ -198,11 +198,11 @@ where
 
 impl<M> IpBpfStateV6<M>
 where
-    M: BpfMap<Key = LpmKey<u128>, Value = IdentityId>,
+    M: BpfMap<Key = LpmKey<u128>, Value = IdentityId, KeyOutput = IpNetwork>,
 {
-    pub fn new(bpf_map: M) -> Self {
-        let cache = ahash::HashMap::default();
-        Self { cache, bpf_map }
+    pub fn try_new(bpf_map: M) -> Result<Self> {
+        let cache = bpf_map.get_state()?;
+        Ok(Self { cache, bpf_map })
     }
 
     pub fn update(&mut self, key: M::Key, value: M::Value) -> Result<()> {

--- a/mesh-cni/src/bpf/service/state.rs
+++ b/mesh-cni/src/bpf/service/state.rs
@@ -166,7 +166,7 @@ where
     SK: std::hash::Hash + std::cmp::Eq + Clone + Copy,
     EV: Clone + std::cmp::PartialEq + Copy,
 {
-    pub fn new(service_map: S, endpoint_map: E) -> Result<Self>
+    pub fn try_new(service_map: S, endpoint_map: E) -> Result<Self>
     where
         S: BpfMap<Key = SK, Value = ServiceValue, KeyOutput = SK>,
         E: BpfMap<Key = EndpointKey, Value = EV, KeyOutput = EndpointKey>,
@@ -598,7 +598,7 @@ mod test {
     > {
         let service_map: HashMap<ServiceKeyV4, ServiceValue> = HashMap::default();
         let endpoint_map: HashMap<EndpointKey, EndpointValueV4> = HashMap::default();
-        ServiceEndpoint::new(service_map, endpoint_map).unwrap()
+        ServiceEndpoint::try_new(service_map, endpoint_map).unwrap()
     }
 
     fn new_service_endpoint_state() -> ServiceEndpointState<
@@ -616,8 +616,8 @@ mod test {
         >,
         HashMap<NodePortKey, ServiceKeyV4>,
     > {
-        let service_v4 = ServiceEndpoint::new(HashMap::default(), HashMap::default()).unwrap();
-        let service_v6 = ServiceEndpoint::new(HashMap::default(), HashMap::default()).unwrap();
+        let service_v4 = ServiceEndpoint::try_new(HashMap::default(), HashMap::default()).unwrap();
+        let service_v6 = ServiceEndpoint::try_new(HashMap::default(), HashMap::default()).unwrap();
         let nodeport = HashMap::default();
         ServiceEndpointState::new(service_v4, service_v6, nodeport).unwrap()
     }

--- a/mesh-cni/src/http/grpc/ip.rs
+++ b/mesh-cni/src/http/grpc/ip.rs
@@ -1,4 +1,5 @@
 use aya::maps::lpm_trie::Key as LpmKey;
+use ipnetwork::IpNetwork;
 use mesh_cni_api::ip::v1::{
     IpId, ListIpsReply, ListIpsRequest,
     ip_server::{Ip as IpApi, IpServer},
@@ -11,8 +12,8 @@ use crate::bpf::{BpfMap, ip::IpNetworkState};
 
 pub fn server<IP4, IP6>(state: IpNetworkState<IP4, IP6>) -> IpServer<Server<IP4, IP6>>
 where
-    IP4: BpfMap<Key = LpmKey<u32>, Value = IdentityId>,
-    IP6: BpfMap<Key = LpmKey<u128>, Value = IdentityId>,
+    IP4: BpfMap<Key = LpmKey<u32>, Value = IdentityId, KeyOutput = IpNetwork>,
+    IP6: BpfMap<Key = LpmKey<u128>, Value = IdentityId, KeyOutput = IpNetwork>,
 {
     info!("creating new network state");
     mesh_cni_api::ip::v1::ip_server::IpServer::new(Server::new(state))
@@ -21,16 +22,16 @@ where
 #[derive(Clone)]
 pub struct Server<IP4, IP6>
 where
-    IP4: BpfMap<Key = LpmKey<u32>, Value = IdentityId>,
-    IP6: BpfMap<Key = LpmKey<u128>, Value = IdentityId>,
+    IP4: BpfMap<Key = LpmKey<u32>, Value = IdentityId, KeyOutput = IpNetwork>,
+    IP6: BpfMap<Key = LpmKey<u128>, Value = IdentityId, KeyOutput = IpNetwork>,
 {
     state: IpNetworkState<IP4, IP6>,
 }
 
 impl<IP4, IP6> Server<IP4, IP6>
 where
-    IP4: BpfMap<Key = LpmKey<u32>, Value = IdentityId>,
-    IP6: BpfMap<Key = LpmKey<u128>, Value = IdentityId>,
+    IP4: BpfMap<Key = LpmKey<u32>, Value = IdentityId, KeyOutput = IpNetwork>,
+    IP6: BpfMap<Key = LpmKey<u128>, Value = IdentityId, KeyOutput = IpNetwork>,
 {
     pub fn new(state: IpNetworkState<IP4, IP6>) -> Self {
         Self { state }
@@ -40,8 +41,14 @@ where
 #[tonic::async_trait]
 impl<IP4, IP6> IpApi for Server<IP4, IP6>
 where
-    IP4: BpfMap<Key = LpmKey<u32>, Value = IdentityId> + Send + Sync + 'static,
-    IP6: BpfMap<Key = LpmKey<u128>, Value = IdentityId> + Send + Sync + 'static,
+    IP4: BpfMap<Key = LpmKey<u32>, Value = IdentityId, KeyOutput = IpNetwork>
+        + Send
+        + Sync
+        + 'static,
+    IP6: BpfMap<Key = LpmKey<u128>, Value = IdentityId, KeyOutput = IpNetwork>
+        + Send
+        + Sync
+        + 'static,
 {
     async fn list_ips(
         &self,


### PR DESCRIPTION
IP cache was not hydrating from map like policy and service are. This changes behavior to be consistent across bpf map/caches.