### PR TITLE
mesh-cni-ebpf: initial handling of fragmented packets

### DIFF
--- a/mesh-cni-ebpf-common/src/conntrack.rs
+++ b/mesh-cni-ebpf-common/src/conntrack.rs
@@ -53,23 +53,23 @@ impl TcpState {
         let Some(flags) = tcp_flags else {
             return Some(Self::None);
         };
-        if flags.rst {
+        if flags.rst() {
             return Some(Self::Rst);
         }
-        if flags.fin {
+        if flags.fin() {
             return Some(if is_reply {
                 Self::FinResponder
             } else {
                 Self::FinInitiator
             });
         }
-        if flags.syn && flags.ack {
+        if flags.syn() && flags.ack() {
             return Some(Self::Syn);
         }
-        if flags.syn && !flags.ack {
+        if flags.syn() && !flags.ack() {
             return Some(Self::Syn);
         }
-        if flags.ack && !flags.syn {
+        if flags.ack() && !flags.syn() {
             return Some(Self::Established);
         }
         Some(Self::None)
@@ -111,12 +111,48 @@ impl TcpState {
     }
 }
 
+#[repr(transparent)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct TcpFlags {
-    pub syn: bool,
-    pub ack: bool,
-    pub fin: bool,
-    pub rst: bool,
+pub struct TcpFlags(pub u8);
+
+impl TcpFlags {
+    pub const SYN: u8 = 1 << 0;
+    pub const ACK: u8 = 1 << 1;
+    pub const FIN: u8 = 1 << 2;
+    pub const RST: u8 = 1 << 3;
+
+    pub const fn new(syn: bool, ack: bool, fin: bool, rst: bool) -> Self {
+        let mut bits = 0;
+        if syn {
+            bits |= Self::SYN;
+        }
+        if ack {
+            bits |= Self::ACK;
+        }
+        if fin {
+            bits |= Self::FIN;
+        }
+        if rst {
+            bits |= Self::RST;
+        }
+        Self(bits)
+    }
+
+    pub const fn syn(self) -> bool {
+        (self.0 & Self::SYN) != 0
+    }
+
+    pub const fn ack(self) -> bool {
+        (self.0 & Self::ACK) != 0
+    }
+
+    pub const fn fin(self) -> bool {
+        (self.0 & Self::FIN) != 0
+    }
+
+    pub const fn rst(self) -> bool {
+        (self.0 & Self::RST) != 0
+    }
 }
 
 #[repr(C)]
@@ -248,12 +284,7 @@ mod tests {
 
     #[test]
     fn classifies_fin_by_direction() {
-        let flags = Some(TcpFlags {
-            syn: false,
-            ack: true,
-            fin: true,
-            rst: false,
-        });
+        let flags = Some(TcpFlags::new(false, true, true, false));
 
         assert_eq!(
             TcpState::from_packet(KubeProtocol::Tcp, flags, false),
@@ -287,12 +318,7 @@ mod tests {
 
     #[test]
     fn classifies_syn_ack_as_syn() {
-        let flags = Some(TcpFlags {
-            syn: true,
-            ack: true,
-            fin: false,
-            rst: false,
-        });
+        let flags = Some(TcpFlags::new(true, true, false, false));
 
         assert_eq!(
             TcpState::from_packet(KubeProtocol::Tcp, flags, true),

--- a/mesh-cni-ebpf-common/src/fragment.rs
+++ b/mesh-cni-ebpf-common/src/fragment.rs
@@ -1,0 +1,48 @@
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+pub struct FragmentKeyV4 {
+    /// Stored in host order
+    pub src_ip: u32,
+    /// Stored in host order
+    pub dst_ip: u32,
+    /// Stored in host order
+    pub id: u16,
+    /// Stored in host order
+    pub protocol: u8,
+    pub _pad: [u8; 3],
+}
+
+impl FragmentKeyV4 {
+    pub fn new(src_ip: u32, dst_ip: u32, id: u16, protocol: u8) -> Self {
+        Self {
+            src_ip,
+            dst_ip,
+            id,
+            protocol,
+            _pad: [0; 3],
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+pub struct FragmentValue {
+    /// Time of creation
+    pub created_ns: u64,
+    /// Stored in host order
+    pub src_port: u16,
+    /// Stored in host order
+    pub dst_port: u16,
+    pub _pad: [u8; 4],
+}
+
+impl FragmentValue {
+    pub fn new(src_port: u16, dst_port: u16, created_ns: u64) -> Self {
+        Self {
+            src_port,
+            dst_port,
+            created_ns,
+            _pad: [0; 4],
+        }
+    }
+}

--- a/mesh-cni-ebpf-common/src/lib.rs
+++ b/mesh-cni-ebpf-common/src/lib.rs
@@ -1,6 +1,7 @@
 #![no_std]
 
 pub mod conntrack;
+pub mod fragment;
 pub mod policy;
 pub mod service;
 pub mod vxlan;
@@ -10,6 +11,8 @@ use core::{
     hash::Hash,
     net::{IpAddr, Ipv6Addr},
 };
+
+use network_types::ip::IpProto;
 
 pub type IdentityId = u32;
 pub type Id = u16;
@@ -105,6 +108,21 @@ impl TryFrom<u32> for KubeProtocol {
             }
         };
         Ok(proto)
+    }
+}
+
+impl TryFrom<u8> for KubeProtocol {
+    type Error = &'static str;
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        KubeProtocol::try_from(value as u32)
+    }
+}
+
+impl TryFrom<IpProto> for KubeProtocol {
+    type Error = &'static str;
+
+    fn try_from(value: IpProto) -> Result<Self, Self::Error> {
+        KubeProtocol::try_from(value as u8)
     }
 }
 

--- a/mesh-cni-ebpf/src/egress.rs
+++ b/mesh-cni-ebpf/src/egress.rs
@@ -9,20 +9,21 @@ use aya_ebpf::{
 use aya_log_ebpf::{error, warn};
 use mesh_cni_ebpf_common::{
     KubeProtocol,
-    conntrack::{ConntrackValue, TcpFlags},
+    conntrack::ConntrackValue,
+    fragment::{FragmentKeyV4, FragmentValue},
     policy::{Action, PolicyDirection, WORLD_ID},
     service::NodePortRevNatV4Key,
 };
 use network_types::{
     eth::{EthHdr, EtherType},
     ip::Ipv4Hdr,
-    sctp::SctpHdr,
-    tcp::TcpHdr,
-    udp::UdpHdr,
 };
 
 use crate::{
-    CONNTRACK_V4, NODEPORT_REV_NAT_V4, id_v4,
+    CONNTRACK_V4, FRAGMENT_V4, NODEPORT_REV_NAT_V4,
+    fragment::is_first_frag_v4,
+    id_v4,
+    l4::l4_header_check,
     policy::{check_cidr_policy_v4, check_identity_policy, conntrack_hit, conntrack_keys},
 };
 
@@ -49,49 +50,20 @@ fn handle_ipv4(ctx: TcContext) -> Result<i32, i32> {
     let src_ip = u32::from_be_bytes(ipv4hdr.src_addr);
     let dst_ip = u32::from_be_bytes(ipv4hdr.dst_addr);
 
-    let (proto, src_port, dst_port, should_insert, tcp_flags) = match ipv4hdr.proto {
-        network_types::ip::IpProto::Tcp => {
-            let tcphdr: TcpHdr = ctx
-                .load(EthHdr::LEN + ipv4hdr.ihl() as usize)
-                .map_err(|_| TC_ACT_PIPE)?;
-            let syn = tcphdr.syn() == 1;
-            let ack = tcphdr.ack() == 1;
-            let fin = tcphdr.fin() == 1;
-            let rst = tcphdr.rst() == 1;
-            (
-                KubeProtocol::Tcp,
-                u16::from_be_bytes(tcphdr.source),
-                u16::from_be_bytes(tcphdr.dest),
-                syn && !ack,
-                Some(TcpFlags { syn, ack, fin, rst }),
-            )
-        }
-        network_types::ip::IpProto::Udp => {
-            let udphdr: UdpHdr = ctx
-                .load(EthHdr::LEN + ipv4hdr.ihl() as usize)
-                .map_err(|_| TC_ACT_PIPE)?;
-            (
-                KubeProtocol::Udp,
-                u16::from_be_bytes(udphdr.src),
-                u16::from_be_bytes(udphdr.dst),
-                true,
-                None,
-            )
-        }
-        network_types::ip::IpProto::Sctp => {
-            let sctphdr: SctpHdr = ctx
-                .load(EthHdr::LEN + ipv4hdr.ihl() as usize)
-                .map_err(|_| TC_ACT_PIPE)?;
-            (
-                KubeProtocol::Sctp,
-                u16::from_be_bytes(sctphdr.src),
-                u16::from_be_bytes(sctphdr.dst),
-                true,
-                None,
-            )
-        }
-        _ => return Ok(TC_ACT_PIPE),
+    let Ok(proto) = KubeProtocol::try_from(ipv4hdr.proto) else {
+        return Ok(TC_ACT_PIPE);
     };
+    let l4_check = l4_header_check(&ctx, &ipv4hdr)?;
+    let src_port = l4_check.src_port;
+    let dst_port = l4_check.dst_port;
+    let tcp_flags = l4_check.tcp_flags();
+
+    if is_first_frag_v4(&ipv4hdr) {
+        let key = FragmentKeyV4::new(src_ip, dst_ip, ipv4hdr.id(), proto as u8);
+        let now = unsafe { bpf_ktime_get_ns() };
+        let value = FragmentValue::new(src_port, dst_port, now);
+        FRAGMENT_V4.insert(key, value, 0).map_err(|_| TC_ACT_SHOT)?;
+    }
 
     // Let NodePort reply traffic pass policy/identity checks on this hook.
     // It will be redirected by pod-veth egress and reverse-NATed on mesh_pod ingress.
@@ -136,7 +108,7 @@ fn handle_ipv4(ctx: TcContext) -> Result<i32, i32> {
         );
         return Ok(TC_ACT_SHOT);
     }
-    if should_insert
+    if l4_check.should_insert()
         && src_ip != dst_ip
         && let Err(e) = CONNTRACK_V4.insert(
             ct_key,

--- a/mesh-cni-ebpf/src/fragment.rs
+++ b/mesh-cni-ebpf/src/fragment.rs
@@ -1,0 +1,25 @@
+use network_types::ip::Ipv4Hdr;
+
+/// Fragement timeout set to 30s matching linux kernel default
+// https://docs.kernel.org/5.10/networking/ip-sysctl.html
+pub const FRAG_TIMEOUT: u64 = 30 * 1_000_000_000;
+
+#[inline]
+pub fn is_first_frag_v4(hdr: &Ipv4Hdr) -> bool {
+    more_frags_v4(hdr) && hdr.frag_offset() == 0
+}
+
+#[inline]
+pub fn is_middle_frag_v4(hdr: &Ipv4Hdr) -> bool {
+    more_frags_v4(hdr) && hdr.frag_offset() > 0
+}
+
+#[inline]
+pub fn is_last_frag_v4(hdr: &Ipv4Hdr) -> bool {
+    !(more_frags_v4(hdr)) && hdr.frag_offset() > 0
+}
+
+#[inline]
+fn more_frags_v4(hdr: &Ipv4Hdr) -> bool {
+    (hdr.frag_flags() & 1) != 0
+}

--- a/mesh-cni-ebpf/src/ingress.rs
+++ b/mesh-cni-ebpf/src/ingress.rs
@@ -9,19 +9,20 @@ use aya_ebpf::{
 use aya_log_ebpf::{error, warn};
 use mesh_cni_ebpf_common::{
     KubeProtocol,
-    conntrack::{ConntrackValue, TcpFlags},
+    conntrack::ConntrackValue,
+    fragment::{FragmentKeyV4, FragmentValue},
     policy::{Action, PolicyDirection, WORLD_ID},
 };
 use network_types::{
     eth::{EthHdr, EtherType},
     ip::Ipv4Hdr,
-    sctp::SctpHdr,
-    tcp::TcpHdr,
-    udp::UdpHdr,
 };
 
 use crate::{
-    CONNTRACK_V4, id_v4,
+    CONNTRACK_V4, FRAGMENT_V4,
+    fragment::is_first_frag_v4,
+    id_v4,
+    l4::l4_header_check,
     policy::{check_cidr_policy_v4, check_identity_policy, conntrack_hit, conntrack_keys},
 };
 
@@ -61,49 +62,21 @@ fn handle_ipv4(ctx: TcContext) -> Result<i32, i32> {
         return Ok(TC_ACT_SHOT);
     };
 
-    let (proto, src_port, dst_port, should_insert, tcp_flags) = match ipv4hdr.proto {
-        network_types::ip::IpProto::Tcp => {
-            let tcphdr: TcpHdr = ctx
-                .load(EthHdr::LEN + Ipv4Hdr::LEN)
-                .map_err(|_| TC_ACT_PIPE)?;
-            let syn = tcphdr.syn() == 1;
-            let ack = tcphdr.ack() == 1;
-            let fin = tcphdr.fin() == 1;
-            let rst = tcphdr.rst() == 1;
-            (
-                KubeProtocol::Tcp,
-                u16::from_be_bytes(tcphdr.source),
-                u16::from_be_bytes(tcphdr.dest),
-                syn && !ack,
-                Some(TcpFlags { syn, ack, fin, rst }),
-            )
-        }
-        network_types::ip::IpProto::Udp => {
-            let udphdr: UdpHdr = ctx
-                .load(EthHdr::LEN + Ipv4Hdr::LEN)
-                .map_err(|_| TC_ACT_PIPE)?;
-            (
-                KubeProtocol::Udp,
-                u16::from_be_bytes(udphdr.src),
-                u16::from_be_bytes(udphdr.dst),
-                true,
-                None,
-            )
-        }
-        network_types::ip::IpProto::Sctp => {
-            let sctphdr: SctpHdr = ctx
-                .load(EthHdr::LEN + Ipv4Hdr::LEN)
-                .map_err(|_| TC_ACT_PIPE)?;
-            (
-                KubeProtocol::Sctp,
-                u16::from_be_bytes(sctphdr.src),
-                u16::from_be_bytes(sctphdr.dst),
-                true,
-                None,
-            )
-        }
-        _ => return Ok(TC_ACT_PIPE),
+    let Ok(proto) = KubeProtocol::try_from(ipv4hdr.proto) else {
+        return Ok(TC_ACT_PIPE);
     };
+
+    let l4_check = l4_header_check(&ctx, &ipv4hdr)?;
+    let src_port = l4_check.src_port;
+    let dst_port = l4_check.dst_port;
+    let tcp_flags = l4_check.tcp_flags();
+
+    if is_first_frag_v4(&ipv4hdr) {
+        let key = FragmentKeyV4::new(src_ip, dst_ip, ipv4hdr.id(), proto as u8);
+        let now = unsafe { bpf_ktime_get_ns() };
+        let value = FragmentValue::new(src_port, dst_port, now);
+        FRAGMENT_V4.insert(key, value, 0).map_err(|_| TC_ACT_SHOT)?;
+    }
 
     let (ct_key, ct_rev) = conntrack_keys(src_ip, dst_ip, src_port, dst_port, proto, dst_id);
 
@@ -128,7 +101,7 @@ fn handle_ipv4(ctx: TcContext) -> Result<i32, i32> {
         return Ok(TC_ACT_SHOT);
     }
 
-    if should_insert
+    if l4_check.should_insert()
         && src_ip != dst_ip
         && let Err(e) = CONNTRACK_V4.insert(
             ct_key,

--- a/mesh-cni-ebpf/src/l4.rs
+++ b/mesh-cni-ebpf/src/l4.rs
@@ -1,0 +1,122 @@
+use aya_ebpf::{
+    bindings::{TC_ACT_PIPE, TC_ACT_SHOT},
+    helpers::generated::bpf_ktime_get_ns,
+    programs::TcContext,
+};
+use mesh_cni_ebpf_common::{conntrack::TcpFlags, fragment::FragmentKeyV4};
+use network_types::{eth::EthHdr, ip::Ipv4Hdr, sctp::SctpHdr, tcp::TcpHdr, udp::UdpHdr};
+
+use crate::{
+    FRAGMENT_V4,
+    fragment::{FRAG_TIMEOUT, is_last_frag_v4, is_middle_frag_v4},
+};
+
+#[repr(C)]
+pub(crate) struct L4Check {
+    pub src_port: u16,
+    pub dst_port: u16,
+    pub should_insert: u8,
+    pub has_tcp_flags: u8,
+    pub tcp_flags: u8,
+    pub _pad: [u8; 1],
+}
+
+impl L4Check {
+    #[inline]
+    fn new(src_port: u16, dst_port: u16, should_insert: bool) -> Self {
+        Self {
+            src_port,
+            dst_port,
+            should_insert: should_insert as u8,
+            has_tcp_flags: 0,
+            tcp_flags: 0,
+            _pad: [0; 1],
+        }
+    }
+
+    #[inline]
+    fn with_tcp_flags(mut self, flags: TcpFlags) -> Self {
+        self.has_tcp_flags = 1;
+        self.tcp_flags = flags.0;
+        self
+    }
+
+    #[inline]
+    pub(crate) fn should_insert(&self) -> bool {
+        self.should_insert != 0
+    }
+
+    #[inline]
+    pub(crate) fn tcp_flags(&self) -> Option<TcpFlags> {
+        if self.has_tcp_flags == 0 {
+            return None;
+        }
+
+        Some(TcpFlags(self.tcp_flags))
+    }
+}
+
+#[inline]
+pub(crate) fn l4_header_check(ctx: &TcContext, ipv4hdr: &Ipv4Hdr) -> Result<L4Check, i32> {
+    let src_ip = u32::from_be_bytes(ipv4hdr.src_addr);
+    let dst_ip = u32::from_be_bytes(ipv4hdr.dst_addr);
+    let ihl = ipv4hdr.ihl() as usize;
+    let (src_port, dst_port, should_insert, tcp_flags) =
+        if is_middle_frag_v4(ipv4hdr) || is_last_frag_v4(ipv4hdr) {
+            let key = FragmentKeyV4::new(src_ip, dst_ip, ipv4hdr.id(), ipv4hdr.proto as u8);
+
+            // Fail close on missing fragments to properly enforce network policy
+            let Some(value) = (unsafe { FRAGMENT_V4.get(key).copied() }) else {
+                return Err(TC_ACT_SHOT);
+            };
+            let now = unsafe { bpf_ktime_get_ns() };
+            let age = now.saturating_sub(value.created_ns);
+            if age > FRAG_TIMEOUT {
+                let _ = FRAGMENT_V4.remove(key);
+                return Err(TC_ACT_SHOT);
+            }
+
+            (value.src_port, value.dst_port, false, None)
+        } else {
+            match ipv4hdr.proto {
+                network_types::ip::IpProto::Tcp => {
+                    let tcphdr: TcpHdr = ctx.load(EthHdr::LEN + ihl).map_err(|_| TC_ACT_PIPE)?;
+                    let syn = tcphdr.syn() == 1;
+                    let ack = tcphdr.ack() == 1;
+                    let fin = tcphdr.fin() == 1;
+                    let rst = tcphdr.rst() == 1;
+                    (
+                        u16::from_be_bytes(tcphdr.source),
+                        u16::from_be_bytes(tcphdr.dest),
+                        syn && !ack,
+                        Some(TcpFlags::new(syn, ack, fin, rst)),
+                    )
+                }
+                network_types::ip::IpProto::Udp => {
+                    let udphdr: UdpHdr = ctx.load(EthHdr::LEN + ihl).map_err(|_| TC_ACT_PIPE)?;
+                    (
+                        u16::from_be_bytes(udphdr.src),
+                        u16::from_be_bytes(udphdr.dst),
+                        true,
+                        None,
+                    )
+                }
+                network_types::ip::IpProto::Sctp => {
+                    let sctphdr: SctpHdr = ctx.load(EthHdr::LEN + ihl).map_err(|_| TC_ACT_PIPE)?;
+                    (
+                        u16::from_be_bytes(sctphdr.src),
+                        u16::from_be_bytes(sctphdr.dst),
+                        true,
+                        None,
+                    )
+                }
+                _ => return Err(TC_ACT_PIPE),
+            }
+        };
+
+    let check = L4Check::new(src_port, dst_port, should_insert);
+    Ok(match tcp_flags {
+        Some(flags) => check.with_tcp_flags(flags),
+        None => check,
+    })
+}

--- a/mesh-cni-ebpf/src/lib.rs
+++ b/mesh-cni-ebpf/src/lib.rs
@@ -1,7 +1,9 @@
 #![no_std]
 
 pub mod egress;
+pub mod fragment;
 pub mod ingress;
+pub mod l4;
 pub(crate) mod policy;
 pub mod service;
 pub mod vxlan;
@@ -13,6 +15,7 @@ use aya_ebpf::{
 use mesh_cni_ebpf_common::{
     IdentityId,
     conntrack::{ConntrackKeyV4, ConntrackValue, NodePortConntrackV4Key, NodePortConntrackV4Value},
+    fragment::{FragmentKeyV4, FragmentValue},
     policy::{
         CidrPolicyMapDataV4, CidrPolicyMapDataV6, PolicyIndexKey, PolicyRuleKey, PolicyValue,
         RulesetId,
@@ -80,6 +83,10 @@ static VXLAN_REMOTE_CIDRS_V4: LpmTrie<u32, RemoteNodeV4> = LpmTrie::with_max_ent
 
 #[map(name = "iface_indexes_v4")]
 static IFACE_INDEXES_V4: HashMap<u32, u32> = HashMap::with_max_entries(10, 0);
+
+#[map(name = "fragment_v4")]
+static FRAGMENT_V4: LruHashMap<FragmentKeyV4, FragmentValue> =
+    LruHashMap::with_max_entries(65535, 0);
 
 #[inline]
 fn id_v4(ip: LpmKey<u32>) -> Option<IdentityId> {

--- a/mesh-cni-ebpf/src/policy.rs
+++ b/mesh-cni-ebpf/src/policy.rs
@@ -15,7 +15,7 @@ use mesh_cni_ebpf_common::{
 
 use crate::{CONNTRACK_V4, POLICY_CIDR_V4, POLICY_INDEX, POLICY_RULESET};
 
-#[inline]
+#[inline(always)]
 pub(crate) fn conntrack_hit(
     ctx: &TcContext,
     ct_key: ConntrackKeyV4,
@@ -53,7 +53,7 @@ pub(crate) fn conntrack_hit(
     false
 }
 
-#[inline]
+#[inline(always)]
 fn next_conntrack_value(
     current: ConntrackValue,
     now: u64,
@@ -61,13 +61,17 @@ fn next_conntrack_value(
     tcp_flags: Option<TcpFlags>,
     is_reply: bool,
 ) -> ConntrackValue {
-    let next_state = current
-        .tcp_state()
-        .advance(TcpState::from_packet(proto, tcp_flags, is_reply));
+    let next_state = if tcp_flags.is_none() && proto == KubeProtocol::Tcp {
+        current.tcp_state()
+    } else {
+        current
+            .tcp_state()
+            .advance(TcpState::from_packet(proto, tcp_flags, is_reply))
+    };
     ConntrackValue::new(now, next_state)
 }
 
-#[inline]
+#[inline(always)]
 fn is_conntrack_expired(value: ConntrackValue, now: u64, proto: KubeProtocol) -> bool {
     let timeout = match proto {
         KubeProtocol::Tcp => match value.tcp_state() {

--- a/mesh-cni-ebpf/src/service.rs
+++ b/mesh-cni-ebpf/src/service.rs
@@ -151,7 +151,7 @@ pub fn try_mesh_cni_nodeport_ingress(mut ctx: TcContext) -> Result<i32, i32> {
                 u16::from_be_bytes(tcphdr.dest),
                 u16::from_be_bytes(tcphdr.source),
                 KubeProtocol::Tcp,
-                Some(TcpFlags { syn, ack, fin, rst }),
+                Some(TcpFlags::new(syn, ack, fin, rst)),
             )
         }
         IpProto::Udp => {
@@ -332,7 +332,7 @@ pub fn try_mesh_cni_nodeport_egress(mut ctx: TcContext) -> Result<i32, i32> {
                 u16::from_be_bytes(tcphdr.source),
                 u16::from_be_bytes(tcphdr.dest),
                 KubeProtocol::Tcp,
-                Some(TcpFlags { syn, ack, fin, rst }),
+                Some(TcpFlags::new(syn, ack, fin, rst)),
             )
         }
         IpProto::Udp => {
@@ -453,14 +453,7 @@ fn is_nodeport_conntrack_expired(value: NodePortConntrackV4Value, now: u64, prot
 
 #[inline]
 fn is_initial_tcp_syn(tcp_flags: Option<TcpFlags>) -> bool {
-    matches!(
-        tcp_flags,
-        Some(TcpFlags {
-            syn: true,
-            ack: false,
-            ..
-        })
-    )
+    matches!(tcp_flags, Some(flags) if flags.syn() && !flags.ack())
 }
 
 trait ProtocolExt {


### PR DESCRIPTION
Adds initial handling of fragmented packets on the ingress and egress
programs. If frags come out of order we fail close until the first frag
packet is seen and an entry is entered into the frag map. Converted
TcpFlags to a u8 wrapper. Hit linker issues so changed conntrack helpers
to always inline.
