### PR TITLE
mesh-cni-plugin: use netkit attachments

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,9 +1,0 @@
-[build]
-target = ["aarch64-unknown-linux-musl"]
-# #target = ["aarch64-unknown-linux-musl", "x86_64-unknown-linux-gnu"]
-#
-[target.aarch64-unknown-linux-musl]
-linker = "aarch64-linux-musl-gcc"
-
-# [target.x86_64-unknown-linux-gnu]
-# linker = "x86-64-linux-gnu-gcc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -247,13 +247,30 @@ version = "0.13.1"
 source = "git+https://github.com/aya-rs/aya?branch=main#a7cfc694bd086d13f608f534774e921d9d501246"
 dependencies = [
  "assert_matches",
- "aya-obj",
+ "aya-obj 0.2.1",
  "bitflags 2.9.1",
  "bytes",
  "hashbrown 0.16.0",
  "libc",
  "log",
- "object",
+ "object 0.37.3",
+ "once_cell",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "aya"
+version = "0.13.2"
+source = "git+https://github.com/rcanderson23/aya?branch=netkit-attachments#4dda68b5405257b50194f4069330c03d7ee17482"
+dependencies = [
+ "assert_matches",
+ "aya-obj 0.2.2",
+ "bitflags 2.9.1",
+ "bytes",
+ "hashbrown 0.17.0",
+ "libc",
+ "log",
+ "object 0.39.0",
  "once_cell",
  "thiserror 2.0.17",
 ]
@@ -307,7 +324,7 @@ name = "aya-log"
 version = "0.2.1"
 source = "git+https://github.com/aya-rs/aya?branch=main#a7cfc694bd086d13f608f534774e921d9d501246"
 dependencies = [
- "aya",
+ "aya 0.13.1",
  "aya-log-common",
  "log",
  "thiserror 2.0.17",
@@ -359,7 +376,19 @@ dependencies = [
  "bytes",
  "hashbrown 0.16.0",
  "log",
- "object",
+ "object 0.37.3",
+ "thiserror 2.0.17",
+]
+
+[[package]]
+name = "aya-obj"
+version = "0.2.2"
+source = "git+https://github.com/rcanderson23/aya?branch=netkit-attachments#4dda68b5405257b50194f4069330c03d7ee17482"
+dependencies = [
+ "bytes",
+ "hashbrown 0.17.0",
+ "log",
+ "object 0.39.0",
  "thiserror 2.0.17",
 ]
 
@@ -1091,6 +1120,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+dependencies = [
+ "equivalent",
+ "foldhash 0.2.0",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1724,7 +1763,7 @@ dependencies = [
  "anyhow",
  "async-stream",
  "axum",
- "aya",
+ "aya 0.13.2",
  "aya-build",
  "aya-log",
  "chrono",
@@ -1872,7 +1911,7 @@ dependencies = [
 name = "mesh-cni-ebpf-common"
 version = "0.1.0"
 dependencies = [
- "aya",
+ "aya 0.13.2",
  "network-types",
 ]
 
@@ -1884,7 +1923,7 @@ version = "0.1.0"
 name = "mesh-cni-identity-controller"
 version = "0.1.0"
 dependencies = [
- "aya",
+ "aya 0.13.2",
  "futures",
  "ipnetwork",
  "k8s-openapi",
@@ -1992,7 +2031,7 @@ name = "mesh-cni-plugin"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "aya",
+ "aya 0.13.2",
  "clap",
  "ipnetwork",
  "mesh-cni-api",
@@ -2269,6 +2308,18 @@ checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
  "crc32fast",
  "hashbrown 0.15.4",
+ "indexmap",
+ "memchr",
+]
+
+[[package]]
+name = "object"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63944c133d03f44e75866bbd160b95af0ec3f6a13d936d69d31c81078cbc5baf"
+dependencies = [
+ "crc32fast",
+ "hashbrown 0.16.0",
  "indexmap",
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,45 +1,45 @@
 [workspace]
 resolver = "2"
 members = [
-    "mesh-cni-api",
-    "mesh-cni",
-    "mesh-cni-cli",
-    "mesh-cni-crds-gen",
-    "mesh-cni-ebpf",
-    "mesh-cni-ebpf-common",
-    "mesh-cni-ebpf-meta",
-    "mesh-cni-cluster-controller",
-    "mesh-cni-identity-gen-controller",
-    "mesh-cni-identity-controller",
-    "mesh-cni-k8s-utils",
-    "mesh-cni-netlink",
-    "mesh-cni-plugin",
-    "mesh-cni-policy-controller",
-    "mesh-cni-meshendpoint-gen-controller",
-    "mesh-cni-meshidentityslice-gen-controller",
-    "mesh-cni-crds", 
-    "mesh-cni-service-bpf-controller",
-    "mesh-cni-vxlan-controller",
+  "mesh-cni-api",
+  "mesh-cni",
+  "mesh-cni-cli",
+  "mesh-cni-crds-gen",
+  "mesh-cni-ebpf",
+  "mesh-cni-ebpf-common",
+  "mesh-cni-ebpf-meta",
+  "mesh-cni-cluster-controller",
+  "mesh-cni-identity-gen-controller",
+  "mesh-cni-identity-controller",
+  "mesh-cni-k8s-utils",
+  "mesh-cni-netlink",
+  "mesh-cni-plugin",
+  "mesh-cni-policy-controller",
+  "mesh-cni-meshendpoint-gen-controller",
+  "mesh-cni-meshidentityslice-gen-controller",
+  "mesh-cni-crds",
+  "mesh-cni-service-bpf-controller",
+  "mesh-cni-vxlan-controller",
 ]
 default-members = [
-    "mesh-cni-api",
-    "mesh-cni",
-    "mesh-cni-cli",
-    "mesh-cni-crds-gen",
-    "mesh-cni-ebpf-common",
-    "mesh-cni-ebpf-meta",
-    "mesh-cni-cluster-controller",
-    "mesh-cni-identity-gen-controller",
-    "mesh-cni-identity-controller",
-    "mesh-cni-k8s-utils",
-    "mesh-cni-netlink",
-    "mesh-cni-plugin",
-    "mesh-cni-policy-controller",
-    "mesh-cni-meshendpoint-gen-controller",
-    "mesh-cni-meshidentityslice-gen-controller",
-    "mesh-cni-crds",
-    "mesh-cni-service-bpf-controller",
-    "mesh-cni-vxlan-controller",
+  "mesh-cni-api",
+  "mesh-cni",
+  "mesh-cni-cli",
+  "mesh-cni-crds-gen",
+  "mesh-cni-ebpf-common",
+  "mesh-cni-ebpf-meta",
+  "mesh-cni-cluster-controller",
+  "mesh-cni-identity-gen-controller",
+  "mesh-cni-identity-controller",
+  "mesh-cni-k8s-utils",
+  "mesh-cni-netlink",
+  "mesh-cni-plugin",
+  "mesh-cni-policy-controller",
+  "mesh-cni-meshendpoint-gen-controller",
+  "mesh-cni-meshidentityslice-gen-controller",
+  "mesh-cni-crds",
+  "mesh-cni-service-bpf-controller",
+  "mesh-cni-vxlan-controller",
 ]
 
 [workspace.package]
@@ -50,11 +50,11 @@ edition = "2024"
 ahash = { version = "0.8" }
 async-broadcast = "0.7.2"
 async-stream = "0.3.6"
-aya = { git = "https://github.com/aya-rs/aya", branch = "main"}
-aya-ebpf = { git = "https://github.com/aya-rs/aya", branch = "main"}
-aya-build = { git = "https://github.com/aya-rs/aya", branch = "main"}
-aya-log = { git = "https://github.com/aya-rs/aya", branch = "main"}
-aya-log-ebpf = { git = "https://github.com/aya-rs/aya", branch = "main"}
+aya = { git = "https://github.com/rcanderson23/aya", branch = "netkit-attachments" }
+aya-ebpf = { git = "https://github.com/aya-rs/aya", branch = "main" }
+aya-build = { git = "https://github.com/aya-rs/aya", branch = "main" }
+aya-log = { git = "https://github.com/aya-rs/aya", branch = "main" }
+aya-log-ebpf = { git = "https://github.com/aya-rs/aya", branch = "main" }
 # aya = { version = "0.13.1", default-features = false }
 # aya-build = { version = "0.1.2", default-features = false }
 # aya-ebpf = { version = "0.1.1", default-features = false }
@@ -62,17 +62,17 @@ aya-log-ebpf = { git = "https://github.com/aya-rs/aya", branch = "main"}
 # aya-log-ebpf = { version = "0.1.1", default-features = false }
 
 anyhow = { version = "1", default-features = false }
-axum = { version = "0.8.4", features = ["tokio"]}
+axum = { version = "0.8.4", features = ["tokio"] }
 bytes = { version = "1.11.1" }
 cidr = { version = "0.3.2" }
 clap = { version = "4.5", features = ["derive", "env"] }
 chrono = { version = "0.4", features = ["serde"] }
 futures = { version = "0.3" }
 http-body-util = { version = "0.1.3" }
-http = { version = "1.3.1"}
+http = { version = "1.3.1" }
 hyper = { version = "1.7.0" }
 hyperlocal = { version = "0.9.1" }
-hyper-util = { version = "0.1.16", features = ["client-legacy"]}
+hyper-util = { version = "0.1.16", features = ["client-legacy"] }
 ipnetwork = { version = "0.21" }
 libc = { version = "0.2.159", default-features = false }
 k8s-openapi = { version = "0.26.1" }
@@ -82,7 +82,7 @@ kube = { version = "2.0.1", default-features = false, features = [
   "aws-lc-rs",
   "derive",
   "runtime",
-  "unstable-runtime"
+  "unstable-runtime",
 ] }
 memoffset = { version = "0.9.1" }
 netns-rs = "0.1.0"
@@ -94,9 +94,9 @@ rand = { version = "0.9.2" }
 opentelemetry = { version = "0.31", features = ["trace"] }
 opentelemetry-otlp = { version = "0.31" }
 opentelemetry_sdk = { version = "0.31", features = ["rt-tokio"] }
-schemars = { version = "1.2"} # update after kube-rs bump 
+schemars = { version = "1.2" } # update after kube-rs bump 
 semver = { version = "1" }
-serde = { version = "1.0.219", features = ["derive"]}
+serde = { version = "1.0.219", features = ["derive"] }
 serde_json = { version = "1" }
 serde_yaml = { version = "0.9.34" }
 sha2 = { version = "0.10.9" }
@@ -104,11 +104,11 @@ rtnetlink = { version = "0.20.0" }
 rustables = { version = "0.8.7" }
 tabled = { version = "0.20.0" }
 tokio = { version = "1.47", features = ["full"] }
-tokio-util = { version = "0.7"}
+tokio-util = { version = "0.7" }
 tokio-rustls = { version = "0.26" }
 tokio-stream = { version = "0.1.17" }
-tower = { version = "0.5.2"}
-prost = { version = "0.14.1"}
+tower = { version = "0.5.2" }
+prost = { version = "0.14.1" }
 tonic = { version = "0.14.1" }
 tonic-prost = { version = "0.14.1" }
 tonic-prost-build = { version = "0.14.1" }
@@ -118,7 +118,7 @@ tracing-opentelemetry = "0.32"
 tracing-appender = "0.2.3"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 walkdir = { version = "2.5.0" }
-which = { version = "8.0.0"}
+which = { version = "8.0.0" }
 
 [profile.release.package.mesh-cni-ebpf]
 debug = 2

--- a/mesh-cni-ebpf/src/egress.rs
+++ b/mesh-cni-ebpf/src/egress.rs
@@ -1,7 +1,7 @@
 use core::net::Ipv4Addr;
 
 use aya_ebpf::{
-    bindings::{TC_ACT_PIPE, TC_ACT_SHOT},
+    bindings::tcx_action_base::{TCX_DROP, TCX_NEXT},
     helpers::bpf_ktime_get_ns,
     maps::lpm_trie::Key as LpmKey,
     programs::TcContext,
@@ -29,15 +29,15 @@ use crate::{
 
 #[inline]
 pub fn try_mesh_cni_egress(ctx: TcContext) -> Result<i32, i32> {
-    let ethhdr: EthHdr = ctx.load(0).map_err(|_| TC_ACT_PIPE)?;
+    let ethhdr: EthHdr = ctx.load(0).map_err(|_| TCX_NEXT)?;
 
     let Ok(ether_type) = ethhdr.ether_type() else {
-        return Ok(TC_ACT_PIPE);
+        return Ok(TCX_NEXT);
     };
 
     // TODO: handle ipv6
     if !matches!(ether_type, EtherType::Ipv4) {
-        return Ok(TC_ACT_PIPE);
+        return Ok(TCX_NEXT);
     }
 
     handle_ipv4(ctx)
@@ -45,13 +45,13 @@ pub fn try_mesh_cni_egress(ctx: TcContext) -> Result<i32, i32> {
 
 #[inline]
 fn handle_ipv4(ctx: TcContext) -> Result<i32, i32> {
-    let ipv4hdr: Ipv4Hdr = ctx.load(EthHdr::LEN).map_err(|_| TC_ACT_PIPE)?;
+    let ipv4hdr: Ipv4Hdr = ctx.load(EthHdr::LEN).map_err(|_| TCX_NEXT)?;
 
     let src_ip = u32::from_be_bytes(ipv4hdr.src_addr);
     let dst_ip = u32::from_be_bytes(ipv4hdr.dst_addr);
 
     let Ok(proto) = KubeProtocol::try_from(ipv4hdr.proto) else {
-        return Ok(TC_ACT_PIPE);
+        return Ok(TCX_NEXT);
     };
     let l4_check = l4_header_check(&ctx, &ipv4hdr)?;
     let src_port = l4_check.src_port;
@@ -62,7 +62,7 @@ fn handle_ipv4(ctx: TcContext) -> Result<i32, i32> {
         let key = FragmentKeyV4::new(src_ip, dst_ip, ipv4hdr.id(), proto as u8);
         let now = unsafe { bpf_ktime_get_ns() };
         let value = FragmentValue::new(src_port, dst_port, now);
-        FRAGMENT_V4.insert(key, value, 0).map_err(|_| TC_ACT_SHOT)?;
+        FRAGMENT_V4.insert(key, value, 0).map_err(|_| TCX_DROP)?;
     }
 
     // Let NodePort reply traffic pass policy/identity checks on this hook.
@@ -70,7 +70,7 @@ fn handle_ipv4(ctx: TcContext) -> Result<i32, i32> {
     let rev_nat_key =
         NodePortRevNatV4Key::new_egress(src_ip, dst_ip, src_port, dst_port, proto as u8);
     if unsafe { NODEPORT_REV_NAT_V4.get(rev_nat_key) }.is_some() {
-        return Ok(TC_ACT_PIPE);
+        return Ok(TCX_NEXT);
     }
 
     // LpmTrie expects big endian order for comparisons.
@@ -82,14 +82,14 @@ fn handle_ipv4(ctx: TcContext) -> Result<i32, i32> {
             Ipv4Addr::from_bits(src_ip),
             Ipv4Addr::from_bits(src_ip),
         );
-        return Ok(TC_ACT_SHOT);
+        return Ok(TCX_DROP);
     };
     let dst_id = id_v4(LpmKey::new(32, dst_ip.to_be())).unwrap_or(WORLD_ID);
     let (ct_key, ct_rev) = conntrack_keys(src_ip, dst_ip, src_port, dst_port, proto, src_id);
 
     let now = unsafe { bpf_ktime_get_ns() };
     if conntrack_hit(&ctx, ct_key, ct_rev, now, proto, tcp_flags) {
-        return Ok(TC_ACT_PIPE);
+        return Ok(TCX_NEXT);
     }
 
     if check_identity_policy(src_id, dst_id, dst_port, proto, PolicyDirection::Egress)
@@ -106,7 +106,7 @@ fn handle_ipv4(ctx: TcContext) -> Result<i32, i32> {
             dst_port,
             proto as u8
         );
-        return Ok(TC_ACT_SHOT);
+        return Ok(TCX_DROP);
     }
     if l4_check.should_insert()
         && src_ip != dst_ip
@@ -118,5 +118,5 @@ fn handle_ipv4(ctx: TcContext) -> Result<i32, i32> {
     {
         error!(&ctx, "failed to insert into conntrack: {}", e);
     }
-    Ok(TC_ACT_PIPE)
+    Ok(TCX_NEXT)
 }

--- a/mesh-cni-ebpf/src/ingress.rs
+++ b/mesh-cni-ebpf/src/ingress.rs
@@ -1,7 +1,7 @@
 use core::net::Ipv4Addr;
 
 use aya_ebpf::{
-    bindings::{TC_ACT_PIPE, TC_ACT_SHOT},
+    bindings::tcx_action_base::{TCX_DROP, TCX_NEXT, TCX_PASS},
     helpers::bpf_ktime_get_ns,
     maps::lpm_trie::Key as LpmKey,
     programs::TcContext,
@@ -28,15 +28,15 @@ use crate::{
 
 #[inline]
 pub fn try_mesh_cni_ingress(ctx: TcContext) -> Result<i32, i32> {
-    let ethhdr: EthHdr = ctx.load(0).map_err(|_| TC_ACT_PIPE)?;
+    let ethhdr: EthHdr = ctx.load(0).map_err(|_| TCX_PASS)?;
 
     let Ok(ether_type) = ethhdr.ether_type() else {
-        return Ok(TC_ACT_PIPE);
+        return Ok(TCX_PASS);
     };
 
     // TODO: handle ipv6
     if !matches!(ether_type, EtherType::Ipv4) {
-        return Ok(TC_ACT_PIPE);
+        return Ok(TCX_PASS);
     }
 
     handle_ipv4(ctx)
@@ -44,7 +44,7 @@ pub fn try_mesh_cni_ingress(ctx: TcContext) -> Result<i32, i32> {
 
 #[inline]
 fn handle_ipv4(ctx: TcContext) -> Result<i32, i32> {
-    let ipv4hdr: Ipv4Hdr = ctx.load(EthHdr::LEN).map_err(|_| TC_ACT_PIPE)?;
+    let ipv4hdr: Ipv4Hdr = ctx.load(EthHdr::LEN).map_err(|_| TCX_PASS)?;
 
     let src_ip = u32::from_be_bytes(ipv4hdr.src_addr);
     let dst_ip = u32::from_be_bytes(ipv4hdr.dst_addr);
@@ -59,11 +59,11 @@ fn handle_ipv4(ctx: TcContext) -> Result<i32, i32> {
             Ipv4Addr::from_bits(src_ip),
             Ipv4Addr::from_bits(dst_ip),
         );
-        return Ok(TC_ACT_SHOT);
+        return Ok(TCX_DROP);
     };
 
     let Ok(proto) = KubeProtocol::try_from(ipv4hdr.proto) else {
-        return Ok(TC_ACT_PIPE);
+        return Ok(TCX_PASS);
     };
 
     let l4_check = l4_header_check(&ctx, &ipv4hdr)?;
@@ -75,14 +75,14 @@ fn handle_ipv4(ctx: TcContext) -> Result<i32, i32> {
         let key = FragmentKeyV4::new(src_ip, dst_ip, ipv4hdr.id(), proto as u8);
         let now = unsafe { bpf_ktime_get_ns() };
         let value = FragmentValue::new(src_port, dst_port, now);
-        FRAGMENT_V4.insert(key, value, 0).map_err(|_| TC_ACT_SHOT)?;
+        FRAGMENT_V4.insert(key, value, 0).map_err(|_| TCX_DROP)?;
     }
 
     let (ct_key, ct_rev) = conntrack_keys(src_ip, dst_ip, src_port, dst_port, proto, dst_id);
 
     let now = unsafe { bpf_ktime_get_ns() };
     if conntrack_hit(&ctx, ct_key, ct_rev, now, proto, tcp_flags) {
-        return Ok(TC_ACT_PIPE);
+        return Ok(TCX_NEXT);
     }
     if check_identity_policy(src_id, dst_id, dst_port, proto, PolicyDirection::Ingress)
         == Action::Deny
@@ -98,7 +98,7 @@ fn handle_ipv4(ctx: TcContext) -> Result<i32, i32> {
             dst_port,
             proto as u8
         );
-        return Ok(TC_ACT_SHOT);
+        return Ok(TCX_DROP);
     }
 
     if l4_check.should_insert()
@@ -111,5 +111,5 @@ fn handle_ipv4(ctx: TcContext) -> Result<i32, i32> {
     {
         error!(&ctx, "failed to insert into conntrack: {}", e);
     }
-    Ok(TC_ACT_PIPE)
+    Ok(TCX_NEXT)
 }

--- a/mesh-cni-ebpf/src/l4.rs
+++ b/mesh-cni-ebpf/src/l4.rs
@@ -1,7 +1,5 @@
 use aya_ebpf::{
-    bindings::{TC_ACT_PIPE, TC_ACT_SHOT},
-    helpers::generated::bpf_ktime_get_ns,
-    programs::TcContext,
+    bindings::tcx_action_base::TCX_DROP, helpers::generated::bpf_ktime_get_ns, programs::TcContext,
 };
 use mesh_cni_ebpf_common::{conntrack::TcpFlags, fragment::FragmentKeyV4};
 use network_types::{eth::EthHdr, ip::Ipv4Hdr, sctp::SctpHdr, tcp::TcpHdr, udp::UdpHdr};
@@ -67,20 +65,20 @@ pub(crate) fn l4_header_check(ctx: &TcContext, ipv4hdr: &Ipv4Hdr) -> Result<L4Ch
 
             // Fail close on missing fragments to properly enforce network policy
             let Some(value) = (unsafe { FRAGMENT_V4.get(key).copied() }) else {
-                return Err(TC_ACT_SHOT);
+                return Err(TCX_DROP);
             };
             let now = unsafe { bpf_ktime_get_ns() };
             let age = now.saturating_sub(value.created_ns);
             if age > FRAG_TIMEOUT {
                 let _ = FRAGMENT_V4.remove(key);
-                return Err(TC_ACT_SHOT);
+                return Err(TCX_DROP);
             }
 
             (value.src_port, value.dst_port, false, None)
         } else {
             match ipv4hdr.proto {
                 network_types::ip::IpProto::Tcp => {
-                    let tcphdr: TcpHdr = ctx.load(EthHdr::LEN + ihl).map_err(|_| TC_ACT_PIPE)?;
+                    let tcphdr: TcpHdr = ctx.load(EthHdr::LEN + ihl).map_err(|_| TCX_DROP)?;
                     let syn = tcphdr.syn() == 1;
                     let ack = tcphdr.ack() == 1;
                     let fin = tcphdr.fin() == 1;
@@ -93,7 +91,7 @@ pub(crate) fn l4_header_check(ctx: &TcContext, ipv4hdr: &Ipv4Hdr) -> Result<L4Ch
                     )
                 }
                 network_types::ip::IpProto::Udp => {
-                    let udphdr: UdpHdr = ctx.load(EthHdr::LEN + ihl).map_err(|_| TC_ACT_PIPE)?;
+                    let udphdr: UdpHdr = ctx.load(EthHdr::LEN + ihl).map_err(|_| TCX_DROP)?;
                     (
                         u16::from_be_bytes(udphdr.src),
                         u16::from_be_bytes(udphdr.dst),
@@ -102,7 +100,7 @@ pub(crate) fn l4_header_check(ctx: &TcContext, ipv4hdr: &Ipv4Hdr) -> Result<L4Ch
                     )
                 }
                 network_types::ip::IpProto::Sctp => {
-                    let sctphdr: SctpHdr = ctx.load(EthHdr::LEN + ihl).map_err(|_| TC_ACT_PIPE)?;
+                    let sctphdr: SctpHdr = ctx.load(EthHdr::LEN + ihl).map_err(|_| TCX_DROP)?;
                     (
                         u16::from_be_bytes(sctphdr.src),
                         u16::from_be_bytes(sctphdr.dst),
@@ -110,7 +108,7 @@ pub(crate) fn l4_header_check(ctx: &TcContext, ipv4hdr: &Ipv4Hdr) -> Result<L4Ch
                         None,
                     )
                 }
-                _ => return Err(TC_ACT_PIPE),
+                _ => return Err(TCX_DROP),
             }
         };
 

--- a/mesh-cni-ebpf/src/service.rs
+++ b/mesh-cni-ebpf/src/service.rs
@@ -1,7 +1,10 @@
 use core::mem::offset_of;
 
 use aya_ebpf::{
-    bindings::{BPF_F_MARK_MANGLED_0, BPF_F_PSEUDO_HDR, TC_ACT_PIPE, TC_ACT_SHOT, bpf_sock_addr},
+    bindings::{
+        BPF_F_MARK_MANGLED_0, BPF_F_PSEUDO_HDR, bpf_sock_addr,
+        tcx_action_base::{TCX_DROP, TCX_NEXT},
+    },
     helpers::generated::{bpf_get_prandom_u32, bpf_ktime_get_ns},
     programs::{SockAddrContext, TcContext},
 };
@@ -120,29 +123,27 @@ fn get_position(count: u16) -> u16 {
 // TODO: consider sctp?
 #[inline]
 pub fn try_mesh_cni_nodeport_ingress(mut ctx: TcContext) -> Result<i32, i32> {
-    let ethhdr: EthHdr = ctx.load(0).map_err(|_| TC_ACT_PIPE)?;
+    let ethhdr: EthHdr = ctx.load(0).map_err(|_| TCX_NEXT)?;
     let Ok(ether_type) = ethhdr.ether_type() else {
-        return Ok(TC_ACT_PIPE);
+        return Ok(TCX_NEXT);
     };
     if !matches!(ether_type, EtherType::Ipv4) {
-        return Ok(TC_ACT_PIPE);
+        return Ok(TCX_NEXT);
     }
 
-    let ipv4hdr: Ipv4Hdr = ctx.load(EthHdr::LEN).map_err(|_| TC_ACT_PIPE)?;
+    let ipv4hdr: Ipv4Hdr = ctx.load(EthHdr::LEN).map_err(|_| TCX_NEXT)?;
     let ihl = ipv4hdr.ihl();
     let orig_dst_ip = u32::from_be_bytes(ipv4hdr.dst_addr);
 
     // pass traffic that isn't pointed at IPs assigned to attached ifaces
     // as this could meant for pods
     if unsafe { NODEPORT_LOCAL_ADDRS_V4.get(orig_dst_ip) }.is_none() {
-        return Ok(TC_ACT_PIPE);
+        return Ok(TCX_NEXT);
     }
 
     let (orig_dst_port, src_port, proto, tcp_flags) = match ipv4hdr.proto {
         IpProto::Tcp => {
-            let tcphdr: TcpHdr = ctx
-                .load(EthHdr::LEN + ihl as usize)
-                .map_err(|_| TC_ACT_PIPE)?;
+            let tcphdr: TcpHdr = ctx.load(EthHdr::LEN + ihl as usize).map_err(|_| TCX_NEXT)?;
             let syn = tcphdr.syn() == 1;
             let ack = tcphdr.ack() == 1;
             let fin = tcphdr.fin() == 1;
@@ -155,9 +156,7 @@ pub fn try_mesh_cni_nodeport_ingress(mut ctx: TcContext) -> Result<i32, i32> {
             )
         }
         IpProto::Udp => {
-            let udphdr: UdpHdr = ctx
-                .load(EthHdr::LEN + ihl as usize)
-                .map_err(|_| TC_ACT_PIPE)?;
+            let udphdr: UdpHdr = ctx.load(EthHdr::LEN + ihl as usize).map_err(|_| TCX_NEXT)?;
             (
                 u16::from_be_bytes(udphdr.dst),
                 u16::from_be_bytes(udphdr.src),
@@ -165,26 +164,26 @@ pub fn try_mesh_cni_nodeport_ingress(mut ctx: TcContext) -> Result<i32, i32> {
                 None,
             )
         }
-        _ => return Ok(TC_ACT_PIPE),
+        _ => return Ok(TCX_NEXT),
     };
 
     let nodeport_key = NodePortKey::new(orig_dst_port, proto as u8);
     let Some(service_key) = (unsafe { NODEPORT_SERVICES_V4.get(nodeport_key).copied() }) else {
-        return Ok(TC_ACT_PIPE);
+        return Ok(TCX_NEXT);
     };
 
     let Some(service_value) = (unsafe { SERVICES_V4.get(service_key).copied() }) else {
-        return Ok(TC_ACT_PIPE);
+        return Ok(TCX_NEXT);
     };
     if service_value.count == 0 {
-        return Err(TC_ACT_SHOT);
+        return Err(TCX_DROP);
     }
     let position = get_position(service_value.count);
 
     let endpoints_value = unsafe {
         match ENDPOINTS_V4.get(EndpointKey::new(service_value.id, position)) {
             Some(value) => value,
-            None => return Ok(TC_ACT_PIPE),
+            None => return Ok(TCX_NEXT),
         }
     };
 
@@ -203,7 +202,7 @@ pub fn try_mesh_cni_nodeport_ingress(mut ctx: TcContext) -> Result<i32, i32> {
             l4_offset + offset_of!(UdpHdr, dst),
             l4_offset + offset_of!(UdpHdr, check),
         ),
-        _ => return Ok(TC_ACT_PIPE),
+        _ => return Ok(TCX_NEXT),
     };
 
     let src_ip = u32::from_be_bytes(ipv4hdr.src_addr);
@@ -241,14 +240,14 @@ pub fn try_mesh_cni_nodeport_ingress(mut ctx: TcContext) -> Result<i32, i32> {
         && service_value.count > 1
         && !is_initial_tcp_syn(tcp_flags)
     {
-        return Ok(TC_ACT_SHOT);
+        return Ok(TCX_DROP);
     }
     let next_state = current_state.advance(TcpState::from_packet(proto, tcp_flags, false));
     let conntrack_value =
         NodePortConntrackV4Value::new(new_dst_ip, new_dst_port, proto_u8, next_state, now);
     NODEPORT_CONNTRACK_V4
         .insert(conntrack_key, conntrack_value, 0)
-        .map_err(|_| TC_ACT_PIPE)?;
+        .map_err(|_| TCX_DROP)?;
 
     // Reverse-NAT keys must match reply traffic tuple seen on mesh_pod ingress:
     // backend_ip:backend_port -> client_ip:client_port.
@@ -266,7 +265,7 @@ pub fn try_mesh_cni_nodeport_ingress(mut ctx: TcContext) -> Result<i32, i32> {
             .insert(rev_nat_key, rev_nat_value, 0)
             .map_err(|_| {
                 error!(&ctx, "failed to insert rev nat key");
-                TC_ACT_PIPE
+                TCX_DROP
             })?;
     }
 
@@ -276,7 +275,7 @@ pub fn try_mesh_cni_nodeport_ingress(mut ctx: TcContext) -> Result<i32, i32> {
         new_dst_ip as u64,
         4,
     )
-    .map_err(|_| TC_ACT_PIPE)?;
+    .map_err(|_| TCX_DROP)?;
 
     ctx.l4_csum_replace(
         l4_check_offset,
@@ -284,7 +283,7 @@ pub fn try_mesh_cni_nodeport_ingress(mut ctx: TcContext) -> Result<i32, i32> {
         new_dst_port as u64,
         l4_port_flags,
     )
-    .map_err(|_| TC_ACT_PIPE)?;
+    .map_err(|_| TCX_DROP)?;
 
     ctx.l4_csum_replace(
         l4_check_offset,
@@ -292,38 +291,36 @@ pub fn try_mesh_cni_nodeport_ingress(mut ctx: TcContext) -> Result<i32, i32> {
         new_dst_ip as u64,
         l4_ip_flags,
     )
-    .map_err(|_| TC_ACT_PIPE)?;
+    .map_err(|_| TCX_DROP)?;
 
     ctx.store(dst_ip_offset, &new_dst_ip, 0)
-        .map_err(|_| TC_ACT_PIPE)?;
+        .map_err(|_| TCX_DROP)?;
     ctx.store(dst_port_offset, &new_dst_port, 0)
-        .map_err(|_| TC_ACT_PIPE)?;
+        .map_err(|_| TCX_DROP)?;
 
-    Ok(TC_ACT_PIPE)
+    Ok(TCX_NEXT)
 }
 
 // TODO: implement ipv6
 // TODO: consider sctp?
 #[inline]
 pub fn try_mesh_cni_nodeport_egress(mut ctx: TcContext) -> Result<i32, i32> {
-    let ethhdr: EthHdr = ctx.load(0).map_err(|_| TC_ACT_PIPE)?;
+    let ethhdr: EthHdr = ctx.load(0).map_err(|_| TCX_NEXT)?;
     let Ok(ether_type) = ethhdr.ether_type() else {
-        return Ok(TC_ACT_PIPE);
+        return Ok(TCX_NEXT);
     };
     if !matches!(ether_type, EtherType::Ipv4) {
-        return Ok(TC_ACT_PIPE);
+        return Ok(TCX_NEXT);
     }
 
-    let ipv4hdr: Ipv4Hdr = ctx.load(EthHdr::LEN).map_err(|_| TC_ACT_PIPE)?;
+    let ipv4hdr: Ipv4Hdr = ctx.load(EthHdr::LEN).map_err(|_| TCX_NEXT)?;
     let ihl = ipv4hdr.ihl();
     let src_ip = u32::from_be_bytes(ipv4hdr.src_addr);
     let dst_ip = u32::from_be_bytes(ipv4hdr.dst_addr);
 
     let (src_port, dst_port, proto, tcp_flags) = match ipv4hdr.proto {
         IpProto::Tcp => {
-            let tcphdr: TcpHdr = ctx
-                .load(EthHdr::LEN + ihl as usize)
-                .map_err(|_| TC_ACT_PIPE)?;
+            let tcphdr: TcpHdr = ctx.load(EthHdr::LEN + ihl as usize).map_err(|_| TCX_NEXT)?;
             let syn = tcphdr.syn() == 1;
             let ack = tcphdr.ack() == 1;
             let fin = tcphdr.fin() == 1;
@@ -336,9 +333,7 @@ pub fn try_mesh_cni_nodeport_egress(mut ctx: TcContext) -> Result<i32, i32> {
             )
         }
         IpProto::Udp => {
-            let udphdr: UdpHdr = ctx
-                .load(EthHdr::LEN + ihl as usize)
-                .map_err(|_| TC_ACT_PIPE)?;
+            let udphdr: UdpHdr = ctx.load(EthHdr::LEN + ihl as usize).map_err(|_| TCX_NEXT)?;
             (
                 u16::from_be_bytes(udphdr.src),
                 u16::from_be_bytes(udphdr.dst),
@@ -346,7 +341,7 @@ pub fn try_mesh_cni_nodeport_egress(mut ctx: TcContext) -> Result<i32, i32> {
                 None,
             )
         }
-        _ => return Ok(TC_ACT_PIPE),
+        _ => return Ok(TCX_NEXT),
     };
 
     let ipv4_offset = EthHdr::LEN;
@@ -364,7 +359,7 @@ pub fn try_mesh_cni_nodeport_egress(mut ctx: TcContext) -> Result<i32, i32> {
             l4_offset + offset_of!(UdpHdr, src),
             l4_offset + offset_of!(UdpHdr, check),
         ),
-        _ => return Ok(TC_ACT_PIPE),
+        _ => return Ok(TCX_NEXT),
     };
 
     let l4_ip_flags = proto.l4_ip_flags();
@@ -374,7 +369,7 @@ pub fn try_mesh_cni_nodeport_egress(mut ctx: TcContext) -> Result<i32, i32> {
 
     let rev_nat_key = NodePortRevNatV4Key::new_egress(src_ip, dst_ip, src_port, dst_port, proto_u8);
     let Some(rev_nat_value) = (unsafe { NODEPORT_REV_NAT_V4.get(rev_nat_key).copied() }) else {
-        return Ok(TC_ACT_PIPE);
+        return Ok(TCX_NEXT);
     };
 
     let client_ip = dst_ip;
@@ -387,7 +382,7 @@ pub fn try_mesh_cni_nodeport_egress(mut ctx: TcContext) -> Result<i32, i32> {
         if is_nodeport_conntrack_expired(value, now, proto_u8) {
             let _ = NODEPORT_CONNTRACK_V4.remove(conntrack_key);
             let _ = NODEPORT_REV_NAT_V4.remove(rev_nat_key);
-            return Ok(TC_ACT_SHOT);
+            return Ok(TCX_DROP);
         } else {
             let next_state = value
                 .tcp_state()
@@ -409,7 +404,7 @@ pub fn try_mesh_cni_nodeport_egress(mut ctx: TcContext) -> Result<i32, i32> {
         rev_nat_value.src_ip as u64,
         4,
     )
-    .map_err(|_| TC_ACT_PIPE)?;
+    .map_err(|_| TCX_DROP)?;
 
     ctx.l4_csum_replace(
         l4_check_offset,
@@ -417,7 +412,7 @@ pub fn try_mesh_cni_nodeport_egress(mut ctx: TcContext) -> Result<i32, i32> {
         rev_nat_value.src_port as u64,
         l4_port_flags,
     )
-    .map_err(|_| TC_ACT_PIPE)?;
+    .map_err(|_| TCX_DROP)?;
 
     ctx.l4_csum_replace(
         l4_check_offset,
@@ -425,14 +420,14 @@ pub fn try_mesh_cni_nodeport_egress(mut ctx: TcContext) -> Result<i32, i32> {
         rev_nat_value.src_ip as u64,
         l4_ip_flags,
     )
-    .map_err(|_| TC_ACT_PIPE)?;
+    .map_err(|_| TCX_DROP)?;
 
     ctx.store(src_ip_offset, &rev_nat_value.src_ip, 0)
-        .map_err(|_| TC_ACT_PIPE)?;
+        .map_err(|_| TCX_DROP)?;
     ctx.store(src_port_offset, &rev_nat_value.src_port, 0)
-        .map_err(|_| TC_ACT_PIPE)?;
+        .map_err(|_| TCX_DROP)?;
 
-    Ok(TC_ACT_PIPE)
+    Ok(TCX_NEXT)
 }
 
 #[inline]

--- a/mesh-cni-ebpf/src/vxlan.rs
+++ b/mesh-cni-ebpf/src/vxlan.rs
@@ -1,7 +1,9 @@
 use aya_ebpf::{
     bindings::{
-        BPF_F_ADJ_ROOM_DECAP_L3_IPV4, BPF_F_ADJ_ROOM_FIXED_GSO, TC_ACT_PIPE, TC_ACT_SHOT,
-        bpf_adj_room_mode::BPF_ADJ_ROOM_MAC, bpf_tunnel_key,
+        BPF_F_ADJ_ROOM_DECAP_L3_IPV4, BPF_F_ADJ_ROOM_FIXED_GSO,
+        bpf_adj_room_mode::BPF_ADJ_ROOM_MAC,
+        bpf_tunnel_key,
+        tcx_action_base::{TCX_DROP, TCX_NEXT},
     },
     helpers::generated::{bpf_redirect, bpf_redirect_peer, bpf_skb_set_tunnel_key},
     maps::lpm_trie::Key as LpmKey,
@@ -24,23 +26,23 @@ const VXLAN_PORT: u16 = 4789;
 // TODO: implement ipv6
 #[inline]
 pub fn try_mesh_cni_vxlan_veth_egress(ctx: TcContext) -> Result<i32, i32> {
-    let ethhdr: EthHdr = ctx.load(0).map_err(|_| TC_ACT_PIPE)?;
+    let ethhdr: EthHdr = ctx.load(0).map_err(|_| TCX_NEXT)?;
     let Ok(ether_type) = ethhdr.ether_type() else {
-        return Ok(TC_ACT_PIPE);
+        return Ok(TCX_NEXT);
     };
     if !matches!(ether_type, EtherType::Ipv4) {
-        return Ok(TC_ACT_PIPE);
+        return Ok(TCX_NEXT);
     }
 
-    let ipv4hdr: Ipv4Hdr = ctx.load(EthHdr::LEN).map_err(|_| TC_ACT_PIPE)?;
+    let ipv4hdr: Ipv4Hdr = ctx.load(EthHdr::LEN).map_err(|_| TCX_NEXT)?;
     let dst_ip = u32::from_be_bytes(ipv4hdr.dst_addr);
 
     let Some(remote) = ROUTER_V4.get(LpmKey::new(32, dst_ip.to_be())).copied() else {
-        return Ok(TC_ACT_PIPE);
+        return Ok(TCX_NEXT);
     };
 
     if remote.route_type != RouteType::RemotePod as u8 {
-        return Ok(TC_ACT_PIPE);
+        return Ok(TCX_NEXT);
     }
 
     let mut key = bpf_tunnel_key {
@@ -64,12 +66,12 @@ pub fn try_mesh_cni_vxlan_veth_egress(ctx: TcContext) -> Result<i32, i32> {
     } {
         rc if rc < 0 => {
             error!(&ctx, "failed to set tunnel, got {}", rc);
-            Err(TC_ACT_SHOT)
+            Err(TCX_DROP)
         }
         _ => match unsafe { bpf_redirect(remote.ifindex, 0) } {
             rc if rc < 0 => {
                 error!(&ctx, "failed to redirect packet, got {}", rc);
-                Err(TC_ACT_SHOT)
+                Err(TCX_DROP)
             }
             rc => Ok(rc as i32),
         },
@@ -79,36 +81,36 @@ pub fn try_mesh_cni_vxlan_veth_egress(ctx: TcContext) -> Result<i32, i32> {
 // TODO: implement ipv6
 #[inline]
 pub fn try_mesh_cni_vxlan_node_ingress(ctx: TcContext) -> Result<i32, i32> {
-    let ethhdr: EthHdr = ctx.load(0).map_err(|_| TC_ACT_PIPE)?;
+    let ethhdr: EthHdr = ctx.load(0).map_err(|_| TCX_NEXT)?;
     let Ok(ether_type) = ethhdr.ether_type() else {
-        return Ok(TC_ACT_PIPE);
+        return Ok(TCX_NEXT);
     };
     if !matches!(ether_type, EtherType::Ipv4) {
-        return Ok(TC_ACT_PIPE);
+        return Ok(TCX_NEXT);
     }
 
-    let ipv4hdr: Ipv4Hdr = ctx.load(EthHdr::LEN).map_err(|_| TC_ACT_PIPE)?;
+    let ipv4hdr: Ipv4Hdr = ctx.load(EthHdr::LEN).map_err(|_| TCX_NEXT)?;
     if !matches!(ipv4hdr.proto, IpProto::Udp) {
-        return Ok(TC_ACT_PIPE);
+        return Ok(TCX_NEXT);
     }
 
     let ihl = ipv4hdr.ihl() as usize;
     let udp_offset = EthHdr::LEN + ihl;
-    let udphdr: UdpHdr = ctx.load(udp_offset).map_err(|_| TC_ACT_PIPE)?;
+    let udphdr: UdpHdr = ctx.load(udp_offset).map_err(|_| TCX_NEXT)?;
     let dst_port = u16::from_be_bytes(udphdr.dst);
     if dst_port != VXLAN_PORT {
-        return Ok(TC_ACT_PIPE);
+        return Ok(TCX_NEXT);
     }
 
     let vxlan_offset = udp_offset + UdpHdr::LEN;
-    let vxlanhdr: VxlanHdr = ctx.load(vxlan_offset).map_err(|_| TC_ACT_PIPE)?;
+    let vxlanhdr: VxlanHdr = ctx.load(vxlan_offset).map_err(|_| TCX_NEXT)?;
     if (vxlanhdr.flags & VXLAN_I_FLAG) == 0 {
         warn!(&ctx, "dropping vxlan packet without valid I flag");
-        return Ok(TC_ACT_SHOT);
+        return Ok(TCX_DROP);
     }
 
     if vxlanhdr.vni() != 1 {
-        return Ok(TC_ACT_SHOT);
+        return Ok(TCX_DROP);
     }
 
     let remove_len = ihl + UdpHdr::LEN + VxlanHdr::LEN + EthHdr::LEN;
@@ -119,33 +121,33 @@ pub fn try_mesh_cni_vxlan_node_ingress(ctx: TcContext) -> Result<i32, i32> {
     )
     .map_err(|e| {
         error!(&ctx, "failed to decapsulate vxlan packet, got {}", e);
-        TC_ACT_SHOT
+        TCX_DROP
     })?;
 
-    let ethhdr: EthHdr = ctx.load(0).map_err(|_| TC_ACT_PIPE)?;
+    let ethhdr: EthHdr = ctx.load(0).map_err(|_| TCX_NEXT)?;
     let Ok(ether_type) = ethhdr.ether_type() else {
-        return Ok(TC_ACT_PIPE);
+        return Ok(TCX_NEXT);
     };
     if !matches!(ether_type, EtherType::Ipv4) {
-        return Ok(TC_ACT_PIPE);
+        return Ok(TCX_NEXT);
     }
 
-    let ipv4hdr: Ipv4Hdr = ctx.load(EthHdr::LEN).map_err(|_| TC_ACT_PIPE)?;
+    let ipv4hdr: Ipv4Hdr = ctx.load(EthHdr::LEN).map_err(|_| TCX_NEXT)?;
     let dst_ip = u32::from_be_bytes(ipv4hdr.dst_addr);
 
     let Some(remote) = ROUTER_V4.get(LpmKey::new(32, dst_ip.to_be())).copied() else {
-        return Ok(TC_ACT_PIPE);
+        return Ok(TCX_NEXT);
     };
 
     if remote.route_type != RouteType::LocalPod as u8 {
         error!(&ctx, "dropping packet for pod not on this node");
-        return Err(TC_ACT_SHOT);
+        return Err(TCX_DROP);
     }
 
     match unsafe { bpf_redirect_peer(remote.ifindex, 0) } {
         rc if rc < 0 => {
             error!(&ctx, "failed to set tunnel, got {}", rc);
-            Err(TC_ACT_SHOT)
+            Err(TCX_DROP)
         }
         rc => Ok(rc as i32),
     }
@@ -154,26 +156,26 @@ pub fn try_mesh_cni_vxlan_node_ingress(ctx: TcContext) -> Result<i32, i32> {
 // TODO: implement ipv6
 #[inline]
 pub fn try_mesh_cni_host_router_egress(ctx: TcContext) -> Result<i32, i32> {
-    let ethhdr: EthHdr = ctx.load(0).map_err(|_| TC_ACT_PIPE)?;
+    let ethhdr: EthHdr = ctx.load(0).map_err(|_| TCX_NEXT)?;
     let Ok(ether_type) = ethhdr.ether_type() else {
-        return Ok(TC_ACT_PIPE);
+        return Ok(TCX_NEXT);
     };
     if !matches!(ether_type, EtherType::Ipv4) {
-        return Ok(TC_ACT_PIPE);
+        return Ok(TCX_NEXT);
     }
 
-    let ipv4hdr: Ipv4Hdr = ctx.load(EthHdr::LEN).map_err(|_| TC_ACT_PIPE)?;
+    let ipv4hdr: Ipv4Hdr = ctx.load(EthHdr::LEN).map_err(|_| TCX_NEXT)?;
     let dst_ip = u32::from_be_bytes(ipv4hdr.dst_addr);
 
     let Some(remote) = ROUTER_V4.get(LpmKey::new(32, dst_ip.to_be())).copied() else {
-        return Ok(TC_ACT_PIPE);
+        return Ok(TCX_NEXT);
     };
 
     match remote.route_type {
         x if x == RouteType::LocalPod as u8 => match unsafe { bpf_redirect(remote.ifindex, 0) } {
             rc if rc < 0 => {
                 error!(&ctx, "failed to redirect local packet, got {}", rc);
-                Err(TC_ACT_SHOT)
+                Err(TCX_DROP)
             }
             rc => Ok(rc as i32),
         },
@@ -203,12 +205,12 @@ pub fn try_mesh_cni_host_router_egress(ctx: TcContext) -> Result<i32, i32> {
             } {
                 rc if rc < 0 => {
                     error!(&ctx, "failed to set tunnel, got {}", rc);
-                    Err(TC_ACT_SHOT)
+                    Err(TCX_DROP)
                 }
                 _ => match unsafe { bpf_redirect(remote.ifindex, 0) } {
                     rc if rc < 0 => {
                         error!(&ctx, "failed to redirect packet, got {}", rc);
-                        Err(TC_ACT_SHOT)
+                        Err(TCX_DROP)
                     }
                     rc => Ok(rc as i32),
                 },
@@ -216,7 +218,7 @@ pub fn try_mesh_cni_host_router_egress(ctx: TcContext) -> Result<i32, i32> {
         }
         unknown => {
             error!(&ctx, "unknown route type {}", unknown);
-            Err(TC_ACT_SHOT)
+            Err(TCX_DROP)
         }
     }
 }

--- a/mesh-cni-netlink/src/handle.rs
+++ b/mesh-cni-netlink/src/handle.rs
@@ -1,16 +1,19 @@
-use std::collections::HashSet;
-use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
-use std::num::NonZero;
-use std::os::fd::RawFd;
+use std::{
+    collections::HashSet,
+    net::{IpAddr, Ipv4Addr, Ipv6Addr},
+    num::NonZero,
+    os::fd::RawFd,
+};
 
 use ipnetwork::IpNetwork;
 use regex::Regex;
-use rtnetlink::packet_route::address::{AddressAttribute, AddressMessage};
-use rtnetlink::packet_route::link::NetkitMode;
-use rtnetlink::packet_route::route::{RouteHeader, RouteMetric, RouteScope};
-use rtnetlink::{Handle, packet_route::link::LinkAttribute};
 use rtnetlink::{
-    LinkDummy, LinkNetkit, LinkUnspec, LinkVxlan, RouteMessageBuilder,
+    Handle, LinkDummy, LinkNetkit, LinkUnspec, LinkVxlan, RouteMessageBuilder,
+    packet_route::{
+        address::{AddressAttribute, AddressMessage},
+        link::{LinkAttribute, NetkitMode},
+        route::{RouteHeader, RouteMetric, RouteScope},
+    },
 };
 use tokio_stream::StreamExt;
 
@@ -214,7 +217,11 @@ impl Netlink {
     pub async fn create_netkit_pair(&self, name: &str, peer_name: &str) -> Result<(u32, u32)> {
         self.handle
             .link()
-            .add(LinkNetkit::new(name, peer_name, NetkitMode::L3).up().build())
+            .add(
+                LinkNetkit::new(name, peer_name, NetkitMode::L3)
+                    .up()
+                    .build(),
+            )
             .execute()
             .await?;
 

--- a/mesh-cni-plugin/src/ebpf.rs
+++ b/mesh-cni-plugin/src/ebpf.rs
@@ -1,23 +1,20 @@
 use std::path::{Path, PathBuf};
 
-use aya::programs::links::{FdLink, LinkError, PinnedLink};
-use aya::programs::{SchedClassifier, TcAttachType, tc};
+use aya::programs::{
+    LinkOrder, SchedClassifier, TcxAttachType,
+    links::{FdLink, LinkError, PinnedLink},
+    tc::{NetkitAttachType, SchedClassifierAttachment},
+};
 use mesh_cni_ebpf_meta::{
     BPF_MESH_LINKS_DIR, BPF_PROGRAM_EGRESS_TC, BPF_PROGRAM_INGRESS_TC,
     BPF_PROGRAM_VXLAN_VETH_EGRESS_TC,
 };
 use tracing::error;
 
-use crate::MESH_LINK_PREFIX;
-use crate::error::Error;
+use crate::{MESH_LINK_PREFIX, error::Error};
 
 pub(crate) fn attach_pod_bpf(pod_iface: &str, container_id: &str) -> Result<(), Error> {
-    if let Err(e) = attach_for_iface(
-        pod_iface,
-        container_id,
-        TcAttachType::Ingress,
-        TcAttachType::Egress,
-    ) {
+    if let Err(e) = attach_for_iface(pod_iface, container_id) {
         error!(%e, "failed to attach tc programs");
         if let Err(u) = unpin_iface_paths(container_id, pod_iface) {
             error!(%u, "failed to unpin path");
@@ -47,11 +44,30 @@ fn unpin_path(path: impl AsRef<Path>) -> Result<(), Error> {
     Ok(())
 }
 
-fn attach_type_name(attach_type: TcAttachType) -> &'static str {
+fn attach_type_name(attach_type: &SchedClassifierAttachment) -> &'static str {
     match attach_type {
-        TcAttachType::Ingress => "ingress",
-        TcAttachType::Egress => "egress",
-        TcAttachType::Custom(_) => "custom",
+        SchedClassifierAttachment::Tc {
+            attach_type,
+            options: _,
+        } => match attach_type {
+            aya::programs::TcAttachType::Ingress => "ingress",
+            aya::programs::TcAttachType::Egress => "egress",
+            aya::programs::TcAttachType::Custom(_) => "custom",
+        },
+        SchedClassifierAttachment::Tcx {
+            attach_type,
+            link_order: _,
+        } => match attach_type {
+            aya::programs::TcxAttachType::Ingress => "ingress",
+            aya::programs::TcxAttachType::Egress => "egress",
+        },
+        SchedClassifierAttachment::Netkit {
+            attach_type,
+            link_order: _,
+        } => match attach_type {
+            NetkitAttachType::Primary => "primary",
+            NetkitAttachType::Peer => "peer",
+        },
     }
 }
 
@@ -59,7 +75,7 @@ fn pin_path(
     container_id: &str,
     iface: &str,
     prog_name: &str,
-    attach_type: TcAttachType,
+    attach_type: &SchedClassifierAttachment,
 ) -> PathBuf {
     let attach_type = attach_type_name(attach_type);
 
@@ -73,16 +89,14 @@ pub(crate) fn attach_and_pin_links(
     container_id: &str,
     path: impl AsRef<Path>,
     prog_name: &str,
-    attach_type: TcAttachType,
+    attach_type: SchedClassifierAttachment,
 ) -> Result<(), Error> {
-    let pin_path = pin_path(container_id, iface, prog_name, attach_type);
+    let pin_path = pin_path(container_id, iface, prog_name, &attach_type);
     if pin_path.try_exists()? {
         return Ok(());
     }
 
     let mut prog = SchedClassifier::from_pin(path)?;
-
-    let _ = tc::qdisc_add_clsact(iface);
 
     let link_id = prog.attach(iface, attach_type)?;
 
@@ -93,8 +107,25 @@ pub(crate) fn attach_and_pin_links(
 }
 
 fn unpin_program_paths(container_id: &str, iface: &str, prog_name: &str) -> Result<(), Error> {
-    for attach_type in [TcAttachType::Ingress, TcAttachType::Egress] {
-        unpin_path(pin_path(container_id, iface, prog_name, attach_type))?;
+    for attach_type in [
+        SchedClassifierAttachment::Netkit {
+            attach_type: NetkitAttachType::Primary,
+            link_order: LinkOrder::default(),
+        },
+        SchedClassifierAttachment::Netkit {
+            attach_type: NetkitAttachType::Peer,
+            link_order: LinkOrder::default(),
+        },
+        SchedClassifierAttachment::Tcx {
+            attach_type: TcxAttachType::Ingress,
+            link_order: LinkOrder::default(),
+        },
+        SchedClassifierAttachment::Tcx {
+            attach_type: TcxAttachType::Egress,
+            link_order: LinkOrder::default(),
+        },
+    ] {
+        unpin_path(pin_path(container_id, iface, prog_name, &attach_type))?;
     }
     Ok(())
 }
@@ -112,14 +143,20 @@ pub(crate) fn attach_host_netkit_bpf(iface: &str, container_id: &str) -> Result<
         container_id,
         BPF_PROGRAM_INGRESS_TC.path(),
         BPF_PROGRAM_INGRESS_TC.name(),
-        TcAttachType::Egress,
+        SchedClassifierAttachment::Netkit {
+            attach_type: NetkitAttachType::Primary,
+            link_order: LinkOrder::default(),
+        },
     )?;
     if let Err(e) = attach_and_pin_links(
         iface,
         container_id,
         BPF_PROGRAM_EGRESS_TC.path(),
         BPF_PROGRAM_EGRESS_TC.name(),
-        TcAttachType::Ingress,
+        SchedClassifierAttachment::Netkit {
+            attach_type: NetkitAttachType::Peer,
+            link_order: LinkOrder::default(),
+        },
     ) {
         if let Err(u) = unpin_host_netkit_bpf(iface, container_id) {
             error!(%u, "failed to unpin host netkit path");
@@ -131,36 +168,58 @@ pub(crate) fn attach_host_netkit_bpf(iface: &str, container_id: &str) -> Result<
         container_id,
         BPF_PROGRAM_VXLAN_VETH_EGRESS_TC.path(),
         BPF_PROGRAM_VXLAN_VETH_EGRESS_TC.name(),
-        TcAttachType::Ingress,
+        SchedClassifierAttachment::Netkit {
+            attach_type: NetkitAttachType::Peer,
+            link_order: LinkOrder::default(),
+        },
     ) {
         if let Err(u) = unpin_host_netkit_bpf(iface, container_id) {
             error!(%u, "failed to unpin host netkit path");
         }
         return Err(e);
     }
+
     Ok(())
 }
 
 pub(crate) fn unpin_host_netkit_bpf(iface: &str, container_id: &str) -> Result<(), Error> {
     for (prog_name, attach_type) in [
-        (BPF_PROGRAM_INGRESS_TC.name(), TcAttachType::Egress),
-        (BPF_PROGRAM_EGRESS_TC.name(), TcAttachType::Ingress),
+        (
+            BPF_PROGRAM_INGRESS_TC.name(),
+            SchedClassifierAttachment::Netkit {
+                attach_type: NetkitAttachType::Primary,
+                link_order: LinkOrder::default(),
+            },
+        ),
+        (
+            BPF_PROGRAM_EGRESS_TC.name(),
+            SchedClassifierAttachment::Netkit {
+                attach_type: NetkitAttachType::Peer,
+                link_order: LinkOrder::default(),
+            },
+        ),
         (
             BPF_PROGRAM_VXLAN_VETH_EGRESS_TC.name(),
-            TcAttachType::Ingress,
+            SchedClassifierAttachment::Netkit {
+                attach_type: NetkitAttachType::Peer,
+                link_order: LinkOrder::default(),
+            },
         ),
     ] {
-        unpin_path(pin_path(container_id, iface, prog_name, attach_type))?;
+        unpin_path(pin_path(container_id, iface, prog_name, &attach_type))?;
     }
     Ok(())
 }
 
-fn attach_for_iface(
-    iface: &str,
-    container_id: &str,
-    ingress_attach_type: TcAttachType,
-    egress_attach_type: TcAttachType,
-) -> Result<(), Error> {
+fn attach_for_iface(iface: &str, container_id: &str) -> Result<(), Error> {
+    let ingress_attach_type = SchedClassifierAttachment::Tcx {
+        attach_type: aya::programs::TcxAttachType::Ingress,
+        link_order: LinkOrder::default(),
+    };
+    let egress_attach_type = SchedClassifierAttachment::Tcx {
+        attach_type: aya::programs::TcxAttachType::Egress,
+        link_order: LinkOrder::default(),
+    };
     attach_and_pin_links(
         iface,
         container_id,

--- a/mesh-cni-plugin/src/response.rs
+++ b/mesh-cni-plugin/src/response.rs
@@ -4,8 +4,10 @@ use semver::Version;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use crate::Result;
-use crate::types::{Dns, Interface, Ip, Route};
+use crate::{
+    Result,
+    types::{Dns, Interface, Ip, Route},
+};
 
 #[derive(Serialize, Deserialize)]
 pub enum Response {

--- a/mesh-cni/src/bpf/service/nodeport_iface.rs
+++ b/mesh-cni/src/bpf/service/nodeport_iface.rs
@@ -10,9 +10,9 @@ use anyhow::anyhow;
 use aya::{
     maps::{HashMap as AyaHashMap, Map, MapData},
     programs::{
-        SchedClassifier, TcAttachType,
+        LinkOrder, SchedClassifier,
         links::{FdLink, LinkError, PinnedLink},
-        tc,
+        tc::{self, TcxAttachType},
     },
 };
 use mesh_cni_netlink::Netlink;
@@ -89,14 +89,14 @@ async fn reconcile(iface_regex: &Regex, nl: &Netlink) -> Result<()> {
             iface,
             BPF_PROGRAM_NODEPORT_INGRESS_TC,
             NODEPORT_LINK_PREFIX,
-            TcAttachType::Ingress,
+            TcxAttachType::Ingress,
         )?;
         info!(%iface, "attaching egress hook to nodeport interface");
         ensure_tc_attached(
             iface,
             BPF_PROGRAM_NODEPORT_EGRESS_TC,
             NODEPORT_LINK_PREFIX,
-            TcAttachType::Egress,
+            TcxAttachType::Egress,
         )?;
     }
 
@@ -213,24 +213,27 @@ fn ensure_tc_attached(
     iface: &str,
     prog: BpfNamePath,
     prefix: &str,
-    attach_type: TcAttachType,
+    attach_type: TcxAttachType,
 ) -> Result<()> {
     let suffix = match attach_type {
-        TcAttachType::Ingress => INGRESS_LINK_SUFFIX,
-        TcAttachType::Egress => EGRESS_LINK_SUFFIX,
-        TcAttachType::Custom(_) => unreachable!(),
+        TcxAttachType::Ingress => INGRESS_LINK_SUFFIX,
+        TcxAttachType::Egress => EGRESS_LINK_SUFFIX,
     };
     let pin_path = pin_path_for_iface(iface, prefix, suffix);
     if pin_path.try_exists()? {
         return Ok(());
     }
 
-    let _ = tc::qdisc_add_clsact(iface);
-
     let mut prog = SchedClassifier::from_pin(prog.path())?;
 
     info!(%iface, "attaching tc program");
-    let link_id = prog.attach(iface, attach_type)?;
+    let link_id = prog.attach(
+        iface,
+        tc::SchedClassifierAttachment::Tcx {
+            attach_type,
+            link_order: LinkOrder::default(),
+        },
+    )?;
     let link = prog.take_link(link_id)?;
     let link: FdLink = link.try_into()?;
     link.pin(pin_path)?;

--- a/mesh-cni/src/system/router.rs
+++ b/mesh-cni/src/system/router.rs
@@ -1,4 +1,4 @@
-use aya::programs::{SchedClassifier, TcAttachType, links::FdLink, tc};
+use aya::programs::{LinkOrder, SchedClassifier, links::FdLink, tc, tc::SchedClassifierAttachment};
 use ipnetwork::IpNetwork;
 use mesh_cni_ebpf_meta::BPF_PROGRAM_HOST_ROUTER_EGRESS_TC;
 use mesh_cni_netlink::Netlink;
@@ -34,10 +34,15 @@ fn ensure_route_ebpf_attached(iface: &str) -> Result<()> {
         return Ok(());
     }
 
-    let _ = tc::qdisc_add_clsact(iface);
-
     let mut prog = SchedClassifier::from_pin(BPF_PROGRAM_HOST_ROUTER_EGRESS_TC.path())?;
-    let link_id = prog.attach(iface, TcAttachType::Egress)?;
+
+    let link_id = prog.attach(
+        iface,
+        SchedClassifierAttachment::Tcx {
+            attach_type: tc::TcxAttachType::Egress,
+            link_order: LinkOrder::default(),
+        },
+    )?;
     let link = prog.take_link(link_id)?;
     let link: FdLink = link.try_into()?;
     link.pin(pin_path)?;

--- a/mesh-cni/src/system/vxlan.rs
+++ b/mesh-cni/src/system/vxlan.rs
@@ -1,4 +1,8 @@
-use aya::programs::{SchedClassifier, TcAttachType, links::FdLink, tc};
+use aya::programs::{
+    LinkOrder, SchedClassifier,
+    links::FdLink,
+    tc::{self, SchedClassifierAttachment},
+};
 use mesh_cni_netlink::Netlink;
 
 use crate::{
@@ -32,7 +36,13 @@ fn ensure_vxlan_node_ingress_attached(iface: &str) -> Result<()> {
     let _ = tc::qdisc_add_clsact(iface);
 
     let mut prog = SchedClassifier::from_pin(BPF_PROGRAM_VXLAN_NODE_INGRESS_TC.path())?;
-    let link_id = prog.attach(iface, TcAttachType::Ingress)?;
+    let link_id = prog.attach(
+        iface,
+        SchedClassifierAttachment::Tcx {
+            attach_type: tc::TcxAttachType::Ingress,
+            link_order: LinkOrder::default(),
+        },
+    )?;
     let link = prog.take_link(link_id)?;
     let link: FdLink = link.try_into()?;
     link.pin(pin_path)?;


### PR DESCRIPTION
This updates attachments to netkit devices to use the netkit attachments. This will temporarily use my aya branch until I get (similar) changes merged. This also requires changes to the ebpf programs as it seems that TC returns are compatible with TCX attachments, they don't appear to be with netkit attachments.